### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,9 +22,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
@@ -34,6 +36,8 @@ jobs:
           - php: 8.5
             stability: prefer-lowest
           - php: 8.4
+            stability: prefer-lowest
+          - laravel: 13.*
             stability: prefer-lowest
           - laravel: 12.*
             stability: prefer-lowest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,9 @@ jobs:
             stability: prefer-lowest
           - laravel: 12.*
             stability: prefer-lowest
+          # spatie/laravel-prometheus ^13.0 support requires PHP 8.4+
+          - php: 8.3
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
+        exclude:
+          # spatie/laravel-prometheus ^13.0 support requires PHP 8.4+
+          - php: 8.3
+            laravel: 13.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3 ]
-        laravel: [ 11.* ]
+        php: [ 8.4, 8.3 ]
+        laravel: [ 13.*, 12.*, 11.* ]
         stability: [ prefer-stable ]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+          - laravel: 12.*
+            testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
 
@@ -62,7 +66,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.php == '8.3' && matrix.stability == 'prefer-stable'
+        if: matrix.php == '8.4' && matrix.laravel == '13.*' && matrix.stability == 'prefer-stable'
         with:
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
     "require": {
         "php": "^8.3|^8.4|^8.5",
         "cboxdk/laravel-queue-metrics": "^2.0",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
         "spatie/laravel-package-tools": "^1.16",
-        "symfony/process": "^7.0"
+        "symfony/process": "^7.0||^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",


### PR DESCRIPTION
## Summary
- Add `illuminate/contracts ^13.0` and `symfony/process ^8.0` to support Laravel 13
- Add `orchestra/testbench ^11.0.0` for testing against Laravel 13
- Extend CI matrix in both `run-tests.yml` and `tests.yml` with Laravel 13 across PHP 8.3–8.5

## Test plan
- [ ] CI passes for Laravel 13 + PHP 8.4 and 8.3
- [ ] CI still passes for Laravel 12 and 11