### PR TITLE
Fix debug command connection, cluster spawn mismatch, and config validation

### DIFF
--- a/src/Commands/DebugQueueCommand.php
+++ b/src/Commands/DebugQueueCommand.php
@@ -12,7 +12,7 @@ class DebugQueueCommand extends Command
 {
     public $signature = 'queue:autoscale:debug
                         {--queue=default : Queue name}
-                        {--connection=database : Queue connection}';
+                        {--connection= : Queue connection (defaults to queue.default config)}';
 
     public $description = 'Debug queue state by showing raw database/redis contents';
 
@@ -22,7 +22,9 @@ class DebugQueueCommand extends Command
         $queue = is_string($queueOpt) ? $queueOpt : 'default';
 
         $connectionOpt = $this->option('connection');
-        $connection = is_string($connectionOpt) ? $connectionOpt : 'database';
+        $defaultConnection = config('queue.default');
+        $fallback = is_string($defaultConnection) ? $defaultConnection : 'database';
+        $connection = is_string($connectionOpt) && $connectionOpt !== '' ? $connectionOpt : $fallback;
 
         $this->info("Debugging queue: {$connection}:{$queue}");
         $this->line('');

--- a/src/Configuration/AutoscaleConfiguration.php
+++ b/src/Configuration/AutoscaleConfiguration.php
@@ -308,12 +308,20 @@ final readonly class AutoscaleConfiguration
      */
     public static function configuredQueues(): array
     {
-        /** @var array<string, array<string, mixed>> $queuesConfig */
+        /** @var array<int|string, mixed> $queuesConfig */
         $queuesConfig = config('queue-autoscale.queues', []);
         $result = [];
 
         foreach ($queuesConfig as $queueName => $config) {
-            $connection = isset($config['connection'])
+            if (! is_string($queueName)) {
+                throw new \InvalidArgumentException(
+                    'Invalid queue-autoscale.queues config: keys must be queue names (strings), not numeric indices. '
+                    ."Expected 'queues' => ['default' => ['connection' => 'redis']], "
+                    .'got a numerically-indexed array instead.'
+                );
+            }
+
+            $connection = is_array($config) && isset($config['connection'])
                 ? self::stringValue($config['connection'], 'default')
                 : 'default';
 

--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -476,13 +476,21 @@ final class AutoscaleManager
         $groups = GroupConfiguration::allFromConfig();
         $groupedQueueKeys = $this->groupedQueueKeys($groups);
 
-        foreach (AutoscaleConfiguration::configuredQueues() as $queueKey => $queueInfo) {
-            if (isset($groupedQueueKeys[$queueKey])) {
+        foreach ($recommendation->workloads as $workloadKey => $target) {
+            if (! str_starts_with($workloadKey, 'queue:')) {
                 continue;
             }
 
-            $connection = $queueInfo['connection'];
-            $queue = $queueInfo['queue'];
+            $parts = explode(':', $workloadKey, 3);
+            if (count($parts) !== 3) {
+                continue;
+            }
+
+            [, $connection, $queue] = $parts;
+
+            if (isset($groupedQueueKeys["{$connection}:{$queue}"])) {
+                continue;
+            }
 
             if (AutoscaleConfiguration::isExcluded($queue)) {
                 continue;
@@ -498,7 +506,6 @@ final class AutoscaleManager
                 continue;
             }
 
-            $target = $recommendation->targetForQueue($connection, $queue);
             $this->reconcileQueueTarget($config, $target);
         }
 

--- a/tests/Feature/ClusterRecommendationApplyTest.php
+++ b/tests/Feature/ClusterRecommendationApplyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterRecommendation;
+use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
+use Illuminate\Support\Facades\Event;
+
+it('applies cluster recommendation for discovered queues not in explicit config', function () {
+    config()->set('queue-autoscale.queues', []);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    expect(AutoscaleConfiguration::configuredQueues())->toBeEmpty();
+
+    Event::fake([WorkersScaled::class]);
+
+    $recommendation = new ClusterRecommendation(
+        managerId: 'test-mgr',
+        issuedAt: now()->timestamp,
+        workloads: [
+            'queue:redis:default' => 2,
+        ],
+    );
+
+    $manager = app(AutoscaleManager::class);
+
+    $method = new ReflectionMethod($manager, 'applyClusterRecommendation');
+    $method->invoke($manager, $recommendation);
+
+    Event::assertDispatched(WorkersScaled::class, function (WorkersScaled $event): bool {
+        return $event->connection === 'redis'
+            && $event->queue === 'default'
+            && $event->from === 0
+            && $event->to === 2
+            && $event->action === 'up';
+    });
+});
+
+it('skips group workloads in cluster recommendation queue loop', function () {
+    config()->set('queue-autoscale.queues', []);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $recommendation = new ClusterRecommendation(
+        managerId: 'test-mgr',
+        issuedAt: now()->timestamp,
+        workloads: [
+            'group:redis:emails' => 3,
+        ],
+    );
+
+    $manager = app(AutoscaleManager::class);
+
+    $method = new ReflectionMethod($manager, 'applyClusterRecommendation');
+    $method->invoke($manager, $recommendation);
+
+    Event::assertNotDispatched(WorkersScaled::class);
+});
+
+it('skips excluded queues in cluster recommendation', function () {
+    config()->set('queue-autoscale.queues', []);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', ['ignored']);
+
+    Event::fake([WorkersScaled::class]);
+
+    $recommendation = new ClusterRecommendation(
+        managerId: 'test-mgr',
+        issuedAt: now()->timestamp,
+        workloads: [
+            'queue:redis:ignored' => 2,
+        ],
+    );
+
+    $manager = app(AutoscaleManager::class);
+
+    $method = new ReflectionMethod($manager, 'applyClusterRecommendation');
+    $method->invoke($manager, $recommendation);
+
+    Event::assertNotDispatched(WorkersScaled::class);
+});

--- a/tests/Feature/DebugQueueCommandTest.php
+++ b/tests/Feature/DebugQueueCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+it('uses config queue.default when no --connection flag is provided', function () {
+    config()->set('queue.default', 'my-conn');
+    config()->set('queue.connections.my-conn.driver', 'null');
+
+    $this->artisan('queue:autoscale:debug')
+        ->expectsOutputToContain('Debugging queue: my-conn:default')
+        ->assertSuccessful();
+});
+
+it('uses the --connection flag value when provided', function () {
+    config()->set('queue.default', 'my-conn');
+    config()->set('queue.connections.other-conn.driver', 'null');
+
+    $this->artisan('queue:autoscale:debug', ['--connection' => 'other-conn'])
+        ->expectsOutputToContain('Debugging queue: other-conn:default')
+        ->assertSuccessful();
+});

--- a/tests/Unit/Configuration/AutoscaleConfigurationQueuesTest.php
+++ b/tests/Unit/Configuration/AutoscaleConfigurationQueuesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
+
+test('returns configured queues keyed by connection:queue', function (): void {
+    config(['queue-autoscale.queues' => [
+        'default' => ['connection' => 'redis'],
+        'payments' => ['connection' => 'sqs'],
+    ]]);
+
+    $queues = AutoscaleConfiguration::configuredQueues();
+
+    expect($queues)->toBe([
+        'redis:default' => ['connection' => 'redis', 'queue' => 'default'],
+        'sqs:payments' => ['connection' => 'sqs', 'queue' => 'payments'],
+    ]);
+});
+
+test('returns empty array when no queues configured', function (): void {
+    config(['queue-autoscale.queues' => []]);
+
+    expect(AutoscaleConfiguration::configuredQueues())->toBeEmpty();
+});
+
+test('throws on numeric-keyed queues config (list-of-dicts shape)', function (): void {
+    config(['queue-autoscale.queues' => [
+        ['connection' => 'redis', 'queue' => 'default'],
+    ]]);
+
+    AutoscaleConfiguration::configuredQueues();
+})->throws(
+    InvalidArgumentException::class,
+    'queue-autoscale.queues'
+);


### PR DESCRIPTION
## Summary

Three related fixes discovered while debugging why `queue:autoscale:debug` showed 0 jobs and `queue:autoscale:cluster` reported `Required workers: 0`:

- **DebugQueueCommand hardcoded `database` connection** — The `--connection` option defaulted to `database` instead of reading `config('queue.default')`. Running the debug command without flags always inspected the database driver, missing jobs on redis.

- **Cluster spawn loop ignored auto-discovered queues** — `applyClusterRecommendation()` iterated only `AutoscaleConfiguration::configuredQueues()` (explicit config), while the leader's calculation loop used `QueueMetrics::getAllQueuesWithMetrics()` (auto-discovery). With `queues => []`, the leader correctly computed required workers but no manager ever spawned them. Fixed by iterating the recommendation's own `workloads` array, which already contains exactly the queues the leader calculated for.

- **`configuredQueues()` silently accepted list-of-dicts** — Passing `[['connection' => 'redis', 'queue' => 'default']]` instead of the expected `['default' => ['connection' => 'redis']]` resulted in numeric array keys being used as queue names, causing a cryptic type error downstream. Now throws a clear `InvalidArgumentException` on the first numeric key.

## Test plan

- [x] `DebugQueueCommandTest` — verifies default connection reads from config, explicit `--connection` still overrides
- [x] `ClusterRecommendationApplyTest` — verifies discovered queues are processed, group workloads are skipped, excluded queues are filtered
- [x] `AutoscaleConfigurationQueuesTest` — verifies correct config shape, empty config, and numeric-key rejection
- [x] Full suite: 443 tests passing, pint clean, phpstan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)