### PR TITLE
Fix ExclusiveProfile cluster bug and add scale-to-zero docs

### DIFF
--- a/docs/basic-usage/workload-profiles.md
+++ b/docs/basic-usage/workload-profiles.md
@@ -176,6 +176,68 @@ Longer forecast horizon (120s) so the aggressive forecast catches ramps earlier.
 
 See [Queue Topology → Exclusive Queues](queue-topology.md#exclusive-sequential-queues) for the full behaviour model.
 
+## Scale-to-Zero
+
+Any scalable profile can scale down to zero workers by setting `workers.min = 0`. Two shipped profiles already do this: `BurstyProfile` and `BackgroundProfile`.
+
+### When to use
+
+Scale-to-zero is appropriate for queues with **sporadic or unpredictable traffic** where it is acceptable that jobs are not processed immediately. Examples:
+
+- Webhook receivers that only fire during external events
+- Nightly report generation
+- Cleanup and maintenance jobs
+- Campaign or batch notification queues
+
+### Wakeup latency
+
+When a queue scales from 0 to 1 worker, there is a **cold-start delay** before the first job is picked up:
+
+| Component | Typical duration |
+|-----------|-----------------|
+| Evaluation interval (polling) | 5 seconds (configurable) |
+| Worker process spawn | 1–3 seconds |
+| Worker poll/sleep loop | 1–3 seconds |
+| **Total wakeup latency** | **~7–11 seconds** |
+
+This delay is inherent to the polling-based architecture: the autoscaler must first observe pending jobs, then spawn a worker, which then polls the queue.
+
+### SLA implications
+
+An SLA target should be **at least 2–3x the wakeup latency** to avoid false breach events on every cold start. For a default 5-second evaluation interval:
+
+- **SLA < 15 seconds:** Will breach on nearly every cold start. Not compatible with scale-to-zero.
+- **SLA 30–60 seconds:** Comfortable buffer. Recommended minimum.
+- **SLA 300+ seconds:** Ideal for background work.
+
+`BurstyProfile` (SLA 60s) and `BackgroundProfile` (SLA 300s) are both designed with this trade-off in mind.
+
+### Configuration
+
+Override `workers.min` on any scalable profile:
+
+```php
+'queues' => [
+    'webhooks' => [
+        'profile' => BalancedProfile::class,
+        'overrides' => ['workers' => ['min' => 0]],
+    ],
+],
+```
+
+Or set it directly:
+
+```php
+'queues' => [
+    'webhooks' => [
+        'sla' => ['target_seconds' => 60],
+        'workers' => ['min' => 0, 'max' => 20],
+    ],
+],
+```
+
+Scale-to-zero is **not compatible** with `ExclusiveProfile` or any non-scalable configuration (`scalable = false`), which requires at least one worker at all times.
+
 ## Custom profiles
 
 If none of the shipped profiles matches your workload, write your own. It's a small class:

--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -501,7 +501,7 @@ final class AutoscaleManager
             if (! $config->workers->scalable) {
                 $rawMetrics = $this->getMetricsForQueue($connection, $queue);
                 $metrics = QueueMetricsData::fromArray($this->mapMetricsFields($rawMetrics));
-                $this->superviseQueue($config, $metrics);
+                $this->superviseQueue($config, $metrics, $target);
 
                 continue;
             }
@@ -1604,16 +1604,20 @@ final class AutoscaleManager
     }
 
     /**
-     * Supervise a non-scalable (pinned) queue: maintain exactly the pinned
-     * worker count. Respawn on death, terminate excess. Never evaluate
-     * scaling. Still tracks SLA breach state for observability parity.
+     * Supervise a non-scalable (pinned) queue: maintain the target worker
+     * count. In non-cluster mode the target is always pinnedCount(). In
+     * cluster mode the leader distributes the pinned count across managers,
+     * so the local target may be 0 (not assigned) or pinnedCount() (assigned).
+     *
+     * Respawns on death, terminates excess. Never evaluates scaling.
+     * Still tracks SLA breach state for observability parity.
      */
-    private function superviseQueue(QueueConfiguration $config, QueueMetricsData $metrics): void
+    private function superviseQueue(QueueConfiguration $config, QueueMetricsData $metrics, ?int $clusterTarget = null): void
     {
         $connection = $config->connection;
         $queue = $config->queue;
         $key = "{$connection}:{$queue}";
-        $target = $config->workers->pinnedCount();
+        $target = $clusterTarget ?? $config->workers->pinnedCount();
         $current = $this->pool->count($connection, $queue);
 
         $this->verbose("  🔒 Exclusive/pinned queue: enforcing {$target} worker(s), current={$current}", 'debug');

--- a/tests/Feature/ScaleToZeroTest.php
+++ b/tests/Feature/ScaleToZeroTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingEngine;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake([
+        ScalingDecisionMade::class,
+        WorkersScaled::class,
+    ]);
+
+    $this->engine = app(ScalingEngine::class);
+});
+
+test('idle queue with min 0 produces target 0', function (): void {
+    $config = makeQueueConfig([
+        'queue' => 'notifications',
+        'minWorkers' => 0,
+        'maxWorkers' => 10,
+        'slaTarget' => 60,
+    ]);
+
+    $idleMetrics = createMetrics([
+        'connection' => 'redis',
+        'queue' => 'notifications',
+        'throughput_per_minute' => 0.0,
+        'active_workers' => 0,
+        'pending' => 0,
+        'oldest_job_age' => 0,
+    ]);
+
+    $decision = $this->engine->evaluate($idleMetrics, $config, 0);
+
+    expect($decision)->toBeInstanceOf(ScalingDecision::class)
+        ->and($decision->targetWorkers)->toBe(0)
+        ->and($decision->shouldHold())->toBeTrue();
+});
+
+test('queue with min 0 scales up when jobs arrive', function (): void {
+    $config = makeQueueConfig([
+        'queue' => 'notifications',
+        'minWorkers' => 0,
+        'maxWorkers' => 10,
+        'slaTarget' => 60,
+    ]);
+
+    $activeMetrics = createMetrics([
+        'connection' => 'redis',
+        'queue' => 'notifications',
+        'throughput_per_minute' => 120.0,
+        'active_workers' => 0,
+        'pending' => 50,
+        'oldest_job_age' => 10,
+    ]);
+
+    $decision = $this->engine->evaluate($activeMetrics, $config, 0);
+
+    expect($decision->targetWorkers)->toBeGreaterThan(0)
+        ->and($decision->shouldScaleUp())->toBeTrue();
+});
+
+test('queue with min 0 scales back to 0 when idle again', function (): void {
+    $config = makeQueueConfig([
+        'queue' => 'notifications',
+        'minWorkers' => 0,
+        'maxWorkers' => 10,
+        'slaTarget' => 60,
+    ]);
+
+    $idleMetrics = createMetrics([
+        'connection' => 'redis',
+        'queue' => 'notifications',
+        'throughput_per_minute' => 0.0,
+        'active_workers' => 0,
+        'pending' => 0,
+        'oldest_job_age' => 0,
+    ]);
+
+    $decision = $this->engine->evaluate($idleMetrics, $config, 3);
+
+    expect($decision->targetWorkers)->toBe(0)
+        ->and($decision->shouldScaleDown())->toBeTrue()
+        ->and($decision->workersToRemove())->toBe(3);
+});

--- a/tests/Unit/Manager/SuperviseQueueClusterTest.php
+++ b/tests/Unit/Manager/SuperviseQueueClusterTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Configuration\Profiles\ExclusiveProfile;
+use Cbox\LaravelQueueAutoscale\Configuration\QueueConfiguration;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerPool;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerProcess;
+use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueMetricsData;
+use Illuminate\Support\Facades\Event;
+use Symfony\Component\Process\Process;
+
+/**
+ * Create a WorkerProcess backed by a Mockery Process stub.
+ *
+ * The stub reports isRunning=true and getPid=$pid so the WorkerPool
+ * counts it as alive. The PID is deliberately non-existent to avoid
+ * signalling real OS processes during terminator calls.
+ */
+function createStubWorkerProcess(string $connection, string $queue, int $pid): WorkerProcess
+{
+    $process = Mockery::mock(Process::class);
+    $process->shouldReceive('getPid')->andReturn($pid);
+    $process->shouldReceive('isRunning')->andReturn(true);
+
+    return new WorkerProcess(
+        process: $process,
+        connection: $connection,
+        queue: $queue,
+        spawnedAt: now(),
+    );
+}
+
+/**
+ * Invoke the private superviseQueue method via reflection.
+ */
+function callSuperviseQueue(
+    AutoscaleManager $manager,
+    QueueConfiguration $config,
+    QueueMetricsData $metrics,
+    ?int $clusterTarget = null,
+): void {
+    $method = new ReflectionMethod($manager, 'superviseQueue');
+    $method->invoke($manager, $config, $metrics, $clusterTarget);
+}
+
+/**
+ * Get the WorkerPool from the manager via reflection.
+ */
+function getPool(AutoscaleManager $manager): WorkerPool
+{
+    $prop = new ReflectionProperty($manager, 'pool');
+
+    return $prop->getValue($manager);
+}
+
+test('cluster target 0 does not spawn workers on empty pool', function (): void {
+    config()->set('queue-autoscale.queues', [
+        'exclusive-queue' => ExclusiveProfile::class,
+    ]);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $manager = app(AutoscaleManager::class);
+    $config = QueueConfiguration::fromConfig('redis', 'exclusive-queue');
+    $metrics = createMetrics(['connection' => 'redis', 'queue' => 'exclusive-queue']);
+
+    callSuperviseQueue($manager, $config, $metrics, clusterTarget: 0);
+
+    $pool = getPool($manager);
+    expect($pool->count('redis', 'exclusive-queue'))->toBe(0);
+    Event::assertNotDispatched(WorkersScaled::class);
+});
+
+test('cluster target 0 terminates existing worker', function (): void {
+    config()->set('queue-autoscale.queues', [
+        'exclusive-queue' => ExclusiveProfile::class,
+    ]);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $manager = app(AutoscaleManager::class);
+    $pool = getPool($manager);
+
+    $existingWorker = createStubWorkerProcess('redis', 'exclusive-queue', 999991);
+    $pool->add($existingWorker);
+
+    $config = QueueConfiguration::fromConfig('redis', 'exclusive-queue');
+    $metrics = createMetrics(['connection' => 'redis', 'queue' => 'exclusive-queue']);
+
+    callSuperviseQueue($manager, $config, $metrics, clusterTarget: 0);
+
+    Event::assertDispatched(WorkersScaled::class, function (WorkersScaled $event): bool {
+        return $event->action === 'down'
+            && $event->from === 1
+            && $event->to === 0
+            && $event->reason === 'supervisor:trim';
+    });
+});
+
+test('cluster target 1 spawns worker on empty pool', function (): void {
+    config()->set('queue-autoscale.queues', [
+        'exclusive-queue' => ExclusiveProfile::class,
+    ]);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $manager = app(AutoscaleManager::class);
+    $config = QueueConfiguration::fromConfig('redis', 'exclusive-queue');
+    $metrics = createMetrics(['connection' => 'redis', 'queue' => 'exclusive-queue']);
+
+    callSuperviseQueue($manager, $config, $metrics, clusterTarget: 1);
+
+    Event::assertDispatched(WorkersScaled::class, function (WorkersScaled $event): bool {
+        return $event->action === 'up'
+            && $event->from === 0
+            && $event->to === 1
+            && $event->reason === 'supervisor:respawn';
+    });
+});
+
+test('null cluster target falls back to pinnedCount', function (): void {
+    config()->set('queue-autoscale.queues', [
+        'exclusive-queue' => ExclusiveProfile::class,
+    ]);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $manager = app(AutoscaleManager::class);
+    $config = QueueConfiguration::fromConfig('redis', 'exclusive-queue');
+    $metrics = createMetrics(['connection' => 'redis', 'queue' => 'exclusive-queue']);
+
+    callSuperviseQueue($manager, $config, $metrics, clusterTarget: null);
+
+    Event::assertDispatched(WorkersScaled::class, function (WorkersScaled $event): bool {
+        return $event->action === 'up' && $event->to === 1;
+    });
+});


### PR DESCRIPTION
## Summary

- **Fix cluster bug**: `ExclusiveProfile` (non-scalable) queues now correctly spawn only 1 worker globally across a multi-manager cluster, instead of 1 per manager. The leader already calculated the correct distribution — followers now respect it via a new optional `?int $clusterTarget` parameter on `superviseQueue()`.
- **Scale-to-zero documentation**: Added a new section to workload profiles docs covering wakeup latency trade-offs, SLA implications, and configuration for queues with `workers.min = 0`.
- **Scale-to-zero tests**: Explicit integration tests verifying the scaling engine produces `targetWorkers: 0` for idle queues and scales back up when jobs arrive.

## Test plan

- [x] 4 new cluster-aware superviseQueue tests (target=0 no-op, target=0 terminates, target=1 spawns, null falls back to pinnedCount)
- [x] 3 new scale-to-zero integration tests (idle→0, jobs→scale up, idle again→0)
- [x] Existing ExclusiveProfile tests pass (regression)
- [x] Full test suite: 450 tests, 0 failures
- [x] PHPStan: 0 errors
- [x] Pint: clean