### PR TITLE
fix: scope process lock per host in cluster mode

### DIFF
--- a/src/Support/ManagerProcessLock.php
+++ b/src/Support/ManagerProcessLock.php
@@ -159,6 +159,12 @@ final class ManagerProcessLock
 
         $appFingerprint = substr(sha1(AutoscaleConfiguration::applicationScopeId()), 0, 16);
 
+        if (AutoscaleConfiguration::clusterEnabled()) {
+            $hostFingerprint = substr(sha1(AutoscaleConfiguration::hostLabel()), 0, 12);
+
+            return $storagePath.DIRECTORY_SEPARATOR."manager-{$appFingerprint}-{$hostFingerprint}.lock";
+        }
+
         return $storagePath.DIRECTORY_SEPARATOR."manager-{$appFingerprint}.lock";
     }
 }

--- a/tests/Unit/Support/ManagerProcessLockTest.php
+++ b/tests/Unit/Support/ManagerProcessLockTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Support\ManagerProcessLock;
+
+it('acquires a lock successfully', function () {
+    $lock = new ManagerProcessLock;
+    $held = $lock->acquire();
+
+    expect($held->metadata())->toHaveKeys(['pid', 'manager_id', 'host', 'acquired_at', 'cluster_enabled']);
+
+    $held->release();
+});
+
+it('prevents a second lock on the same host', function () {
+    $lock1 = new ManagerProcessLock;
+    $held1 = $lock1->acquire();
+
+    $lock2 = new ManagerProcessLock;
+
+    try {
+        $lock2->acquire();
+        $this->fail('Expected RuntimeException');
+    } catch (RuntimeException $e) {
+        expect($e->getMessage())->toContain('Another queue:autoscale manager is already running');
+    } finally {
+        $held1->release();
+    }
+});
+
+it('uses host-scoped lock path in cluster mode', function () {
+    config()->set('queue-autoscale.cluster.enabled', true);
+
+    $lock = new ManagerProcessLock;
+    $held = $lock->acquire();
+
+    $lockDir = storage_path('framework/queue-autoscale');
+    $files = glob($lockDir.'/manager-*.lock');
+
+    // In cluster mode, the lock filename should contain the host fingerprint
+    $hostFingerprint = substr(sha1(gethostname() ?: 'unknown-host'), 0, 12);
+    $matchingFiles = array_filter($files, fn ($f) => str_contains(basename($f), $hostFingerprint));
+
+    expect($matchingFiles)->not->toBeEmpty();
+
+    $held->release();
+});
+
+it('uses app-only lock path in single-host mode', function () {
+    config()->set('queue-autoscale.cluster.enabled', false);
+
+    $lock = new ManagerProcessLock;
+    $held = $lock->acquire();
+
+    $lockDir = storage_path('framework/queue-autoscale');
+    $files = glob($lockDir.'/manager-*.lock');
+
+    // In single-host mode, the lock filename should NOT contain the host fingerprint
+    $hostFingerprint = substr(sha1(gethostname() ?: 'unknown-host'), 0, 12);
+    $matchingFiles = array_filter($files, fn ($f) => str_contains(basename($f), $hostFingerprint));
+
+    expect($matchingFiles)->toBeEmpty();
+
+    $held->release();
+});
+
+afterEach(function () {
+    // Clean up any lock files created during tests
+    $lockDir = storage_path('framework/queue-autoscale');
+    $files = glob($lockDir.'/manager-*.lock');
+
+    if (is_array($files)) {
+        foreach ($files as $file) {
+            @unlink($file);
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- **Bug:** When running `queue:autoscale` in multiple containers with a shared storage volume, the file-based process lock (`flock`) blocked all containers except the first, because the lock filename only used the application fingerprint (identical across all containers in the same cluster).
- **Fix:** In cluster mode, the lock file path now includes a host fingerprint (`hostLabel` SHA), giving each container its own lock file. Cross-node coordination is already handled by Redis leader election.
- Adds unit tests for `ManagerProcessLock` covering both single-host and cluster-mode lock path scoping.

## Test plan

- [x] New `ManagerProcessLockTest` passes (4 tests)
- [x] Full test suite passes (454 tests, 0 failures)
- [x] PHPStan passes with no errors
- [ ] Deploy two+ containers with shared storage volume running `queue:autoscale` in cluster mode — both should start without the `RuntimeException`