### PR TITLE
fix: add target smoothing to prevent oscillation under steady-state load

### DIFF
--- a/src/Scaling/Calculators/TargetSmoother.php
+++ b/src/Scaling/Calculators/TargetSmoother.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Scaling\Calculators;
+
+/**
+ * Smooths target worker count across evaluation cycles to prevent oscillation
+ *
+ * When throughput is stable (coefficient of variation < 5%), limits scale-down
+ * to at most 1 worker per cycle. Scale-up is always unrestricted to preserve
+ * reactivity to genuine load increases.
+ *
+ * This prevents the pattern where transient pending=0 blips cause the strategy
+ * to drop target sharply via Little's Law, only to pump it back up when pending
+ * refills — producing 33%+ oscillation under steady-state load.
+ */
+final class TargetSmoother
+{
+    private const MAX_THROUGHPUT_HISTORY = 10;
+
+    private const STABLE_CV_THRESHOLD = 0.05;
+
+    private const MIN_SAMPLES_FOR_STABILITY = 3;
+
+    private const MAX_SCALE_DOWN_WHEN_STABLE = 1;
+
+    /**
+     * @var array<string, int>
+     */
+    private array $previousTargets = [];
+
+    /**
+     * @var array<string, list<float>>
+     */
+    private array $throughputHistory = [];
+
+    /**
+     * @var array{applied: bool, raw_target: int|null, smoothed_target: int|null, cv: float|null, stable: bool|null}
+     */
+    private array $lastSmoothing = [
+        'applied' => false,
+        'raw_target' => null,
+        'smoothed_target' => null,
+        'cv' => null,
+        'stable' => null,
+    ];
+
+    /**
+     * Smooth target to prevent oscillation during stable throughput
+     *
+     * When throughput is stable and target wants to decrease, limits
+     * the decrease to MAX_SCALE_DOWN_WHEN_STABLE per cycle. Scale-up
+     * is always immediate.
+     *
+     * @param  string  $queueKey  Unique key for the queue (connection:queue)
+     * @param  int  $rawTarget  Target calculated by the strategy (already clamped to bounds)
+     * @param  float  $throughputPerMinute  Current throughput in jobs/minute
+     * @return int Smoothed target worker count
+     */
+    public function smooth(string $queueKey, int $rawTarget, float $throughputPerMinute): int
+    {
+        $this->recordThroughput($queueKey, $throughputPerMinute);
+
+        $previousTarget = $this->previousTargets[$queueKey] ?? null;
+
+        // First call or scaling up: allow immediately
+        if ($previousTarget === null || $rawTarget >= $previousTarget) {
+            $this->previousTargets[$queueKey] = $rawTarget;
+            $this->lastSmoothing = [
+                'applied' => false,
+                'raw_target' => $rawTarget,
+                'smoothed_target' => $rawTarget,
+                'cv' => null,
+                'stable' => null,
+            ];
+
+            return $rawTarget;
+        }
+
+        // Scale-down requested — check throughput stability
+        $cv = $this->coefficientOfVariation($queueKey);
+        $stable = $cv !== null && $cv < self::STABLE_CV_THRESHOLD;
+
+        if ($stable) {
+            // Limit scale-down to 1 worker per cycle
+            $smoothedTarget = max($rawTarget, $previousTarget - self::MAX_SCALE_DOWN_WHEN_STABLE);
+            $this->previousTargets[$queueKey] = $smoothedTarget;
+            $this->lastSmoothing = [
+                'applied' => $smoothedTarget !== $rawTarget,
+                'raw_target' => $rawTarget,
+                'smoothed_target' => $smoothedTarget,
+                'cv' => $cv,
+                'stable' => true,
+            ];
+
+            return $smoothedTarget;
+        }
+
+        // Throughput is volatile — allow full scale-down
+        $this->previousTargets[$queueKey] = $rawTarget;
+        $this->lastSmoothing = [
+            'applied' => false,
+            'raw_target' => $rawTarget,
+            'smoothed_target' => $rawTarget,
+            'cv' => $cv,
+            'stable' => false,
+        ];
+
+        return $rawTarget;
+    }
+
+    /**
+     * @return array{applied: bool, raw_target: int|null, smoothed_target: int|null, cv: float|null, stable: bool|null}
+     */
+    public function getLastSmoothing(): array
+    {
+        return $this->lastSmoothing;
+    }
+
+    public function reset(?string $queueKey = null): void
+    {
+        if ($queueKey !== null) {
+            unset($this->previousTargets[$queueKey], $this->throughputHistory[$queueKey]);
+        } else {
+            $this->previousTargets = [];
+            $this->throughputHistory = [];
+        }
+
+        $this->lastSmoothing = [
+            'applied' => false,
+            'raw_target' => null,
+            'smoothed_target' => null,
+            'cv' => null,
+            'stable' => null,
+        ];
+    }
+
+    private function recordThroughput(string $queueKey, float $throughputPerMinute): void
+    {
+        if (! isset($this->throughputHistory[$queueKey])) {
+            $this->throughputHistory[$queueKey] = [];
+        }
+
+        $this->throughputHistory[$queueKey][] = $throughputPerMinute;
+
+        if (count($this->throughputHistory[$queueKey]) > self::MAX_THROUGHPUT_HISTORY) {
+            array_shift($this->throughputHistory[$queueKey]);
+        }
+    }
+
+    /**
+     * Compute coefficient of variation for the throughput history
+     *
+     * Returns null if insufficient samples or zero mean (no meaningful throughput).
+     */
+    private function coefficientOfVariation(string $queueKey): ?float
+    {
+        $history = $this->throughputHistory[$queueKey] ?? [];
+
+        if (count($history) < self::MIN_SAMPLES_FOR_STABILITY) {
+            return null;
+        }
+
+        $mean = array_sum($history) / count($history);
+
+        if ($mean <= 0.0) {
+            return null;
+        }
+
+        $sumSquaredDiffs = 0.0;
+        foreach ($history as $value) {
+            $sumSquaredDiffs += ($value - $mean) ** 2;
+        }
+
+        $stddev = sqrt($sumSquaredDiffs / count($history));
+
+        return $stddev / $mean;
+    }
+}

--- a/src/Scaling/Strategies/HybridStrategy.php
+++ b/src/Scaling/Strategies/HybridStrategy.php
@@ -13,6 +13,7 @@ use Cbox\LaravelQueueAutoscale\Contracts\SpawnLatencyTrackerContract;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\ArrivalRateEstimator;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\BacklogDrainCalculator;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\LittlesLawCalculator;
+use Cbox\LaravelQueueAutoscale\Scaling\Calculators\TargetSmoother;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueMetricsData;
 
 /**
@@ -45,6 +46,7 @@ final class HybridStrategy implements ScalingStrategyContract
         private readonly SpawnLatencyTrackerContract $spawnTracker,
         private readonly PickupTimeStoreContract $pickupStore,
         private readonly PercentileCalculatorContract $percentileCalc,
+        private readonly TargetSmoother $smoother = new TargetSmoother,
     ) {}
 
     public function calculateTargetWorkers(QueueMetricsData $metrics, QueueConfiguration $config): int
@@ -230,6 +232,23 @@ final class HybridStrategy implements ScalingStrategyContract
             min($config->workers->max, (int) ceil(max($targetWorkers, 0))),
         );
 
+        // Apply hysteresis: limit scale-down to -1/cycle when throughput is stable.
+        // This prevents oscillation at the edge of steady-state load where transient
+        // pending=0 blips cause sharp target drops that immediately reverse.
+        $targetWorkers = $this->smoother->smooth($queueKey, $targetWorkers, $metrics->throughputPerMinute);
+        $targetWorkers = max($config->workers->min, min($config->workers->max, $targetWorkers));
+
+        // Record smoothing info for reason building
+        $smoothing = $this->smoother->getLastSmoothing();
+        if ($smoothing['applied']) {
+            $this->lastCalculation['smoothing'] = sprintf(
+                'target dampened %d→%d (CV=%.1f%%, stable throughput)',
+                $smoothing['raw_target'],
+                $smoothing['smoothed_target'],
+                ($smoothing['cv'] ?? 0) * 100,
+            );
+        }
+
         return $targetWorkers;
     }
 
@@ -296,6 +315,12 @@ final class HybridStrategy implements ScalingStrategyContract
         $utilizationAdj = (string) ($calc['utilization_adjustment'] ?? '');
         if ($utilizationAdj !== '') {
             $parts[] = $utilizationAdj;
+        }
+
+        // Add smoothing note if target was dampened
+        $smoothingNote = (string) ($calc['smoothing'] ?? '');
+        if ($smoothingNote !== '') {
+            $parts[] = $smoothingNote;
         }
 
         return implode('; ', $parts);

--- a/tests/Unit/HybridStrategyBehaviourTest.php
+++ b/tests/Unit/HybridStrategyBehaviourTest.php
@@ -658,3 +658,220 @@ describe('constructor requirements', function () {
         expect($strategy)->toBeInstanceOf(HybridStrategy::class);
     });
 });
+
+describe('target oscillation prevention (issue #15)', function () {
+    it('holds target stable when pending alternates between 0 and 25 with stable throughput', function () {
+        // Scenario from issue #15:
+        // 24 jobs/sec, 12 workers @ 280ms avg → throughput exactly matches capacity
+        // pending oscillates between 0 and 25, throughput stays at 1440/min
+        $config = makeQueueConfig(['minWorkers' => 1, 'maxWorkers' => 12]);
+        $throughput = 1440.0; // 24 jobs/sec × 60
+        $avgDuration = 0.28;  // 280ms
+
+        // Warm-up phase: build arrival rate and smoother history at equilibrium (12 workers)
+        // Need multiple calls with time gaps for arrival estimator to build confidence
+        for ($i = 0; $i < 5; $i++) {
+            $metrics = createMetrics([
+                'throughput_per_minute' => $throughput,
+                'active_workers' => 12,
+                'pending' => 15,
+                'oldest_job_age' => 3,
+                'avg_duration' => $avgDuration,
+            ]);
+            $this->strategy->calculateTargetWorkers($metrics, $config);
+
+            // Age the arrival estimator snapshots so next call sees a valid interval
+            $history = $this->arrivalEstimator->getHistory();
+            if (! empty($history)) {
+                $key = array_key_first($history);
+                foreach ($history[$key] as &$snapshot) {
+                    $snapshot['timestamp'] -= 5;
+                }
+                unset($snapshot);
+
+                $reflection = new ReflectionClass($this->arrivalEstimator);
+                $historyProperty = $reflection->getProperty('history');
+                $historyProperty->setValue($this->arrivalEstimator, $history);
+            }
+        }
+
+        // Capture the equilibrium target after warm-up
+        $equilibriumMetrics = createMetrics([
+            'throughput_per_minute' => $throughput,
+            'active_workers' => 12,
+            'pending' => 15,
+            'oldest_job_age' => 3,
+            'avg_duration' => $avgDuration,
+        ]);
+        $equilibrium = $this->strategy->calculateTargetWorkers($equilibriumMetrics, $config);
+
+        // Oscillation phase: pending alternates between 0 and 25
+        // Throughput stays constant (proving the workload is stable)
+        $targets = [];
+        for ($cycle = 0; $cycle < 30; $cycle++) {
+            $pendingIsZero = ($cycle % 2 === 0);
+
+            // Age arrival estimator between cycles
+            $history = $this->arrivalEstimator->getHistory();
+            if (! empty($history)) {
+                $key = array_key_first($history);
+                foreach ($history[$key] as &$snapshot) {
+                    $snapshot['timestamp'] -= 5;
+                }
+                unset($snapshot);
+
+                $reflection = new ReflectionClass($this->arrivalEstimator);
+                $historyProperty = $reflection->getProperty('history');
+                $historyProperty->setValue($this->arrivalEstimator, $history);
+            }
+
+            $metrics = createMetrics([
+                'throughput_per_minute' => $throughput,
+                'active_workers' => 12,
+                'pending' => $pendingIsZero ? 0 : 25,
+                'oldest_job_age' => $pendingIsZero ? 0 : 5,
+                'avg_duration' => $avgDuration,
+            ]);
+
+            $targets[] = $this->strategy->calculateTargetWorkers($metrics, $config);
+        }
+
+        // Target should never drop more than 1 worker per cycle
+        $previousTarget = $equilibrium;
+        foreach ($targets as $i => $target) {
+            if ($target < $previousTarget) {
+                $drop = $previousTarget - $target;
+                expect($drop)->toBeLessThanOrEqual(1, "Cycle {$i}: dropped {$drop} workers (from {$previousTarget} to {$target})");
+            }
+            $previousTarget = $target;
+        }
+    });
+
+    it('preserves scale-up reactivity when load genuinely increases', function () {
+        // The smoother should NOT slow down scale-up — only scale-down
+        $config = makeQueueConfig(['minWorkers' => 1, 'maxWorkers' => 20]);
+
+        // Build stable history at 5 workers
+        for ($i = 0; $i < 5; $i++) {
+            $metrics = createMetrics([
+                'throughput_per_minute' => 300.0,
+                'active_workers' => 5,
+                'pending' => 2,
+                'oldest_job_age' => 1,
+                'avg_duration' => 1.0,
+            ]);
+            $this->strategy->calculateTargetWorkers($metrics, $config);
+
+            $history = $this->arrivalEstimator->getHistory();
+            if (! empty($history)) {
+                $key = array_key_first($history);
+                foreach ($history[$key] as &$snapshot) {
+                    $snapshot['timestamp'] -= 5;
+                }
+                unset($snapshot);
+
+                $reflection = new ReflectionClass($this->arrivalEstimator);
+                $historyProperty = $reflection->getProperty('history');
+                $historyProperty->setValue($this->arrivalEstimator, $history);
+            }
+        }
+
+        $lastTarget = $this->strategy->calculateTargetWorkers(createMetrics([
+            'throughput_per_minute' => 300.0,
+            'active_workers' => 5,
+            'pending' => 2,
+            'oldest_job_age' => 1,
+            'avg_duration' => 1.0,
+        ]), $config);
+
+        // Sudden load spike: backlog jumps, SLA breach imminent
+        $history = $this->arrivalEstimator->getHistory();
+        if (! empty($history)) {
+            $key = array_key_first($history);
+            foreach ($history[$key] as &$snapshot) {
+                $snapshot['timestamp'] -= 5;
+            }
+            unset($snapshot);
+
+            $reflection = new ReflectionClass($this->arrivalEstimator);
+            $historyProperty = $reflection->getProperty('history');
+            $historyProperty->setValue($this->arrivalEstimator, $history);
+        }
+
+        $spikeMetrics = createMetrics([
+            'throughput_per_minute' => 300.0,
+            'active_workers' => 5,
+            'pending' => 200,
+            'oldest_job_age' => 20,
+            'avg_duration' => 1.0,
+        ]);
+
+        $spikeTarget = $this->strategy->calculateTargetWorkers($spikeMetrics, $config);
+
+        // Scale-up should be immediate and significant — not dampened
+        expect($spikeTarget)->toBeGreaterThan($lastTarget);
+    });
+
+    it('includes smoothing info in reason when target is dampened', function () {
+        $config = makeQueueConfig(['minWorkers' => 1, 'maxWorkers' => 12]);
+
+        // Build stable history at target=12 using heavy backlog near SLA breach.
+        // pending=100, oldestJobAge=27 (90% of SLA=30) produces backlog drain >> 12,
+        // which clamps to max=12.
+        for ($i = 0; $i < 5; $i++) {
+            $metrics = createMetrics([
+                'throughput_per_minute' => 1440.0,
+                'active_workers' => 12,
+                'pending' => 100,
+                'oldest_job_age' => 27, // 27/30 = 90% → heavy backlog drain
+                'avg_duration' => 0.28,
+            ]);
+            $target = $this->strategy->calculateTargetWorkers($metrics, $config);
+
+            $history = $this->arrivalEstimator->getHistory();
+            if (! empty($history)) {
+                $key = array_key_first($history);
+                foreach ($history[$key] as &$snapshot) {
+                    $snapshot['timestamp'] -= 5;
+                }
+                unset($snapshot);
+
+                $reflection = new ReflectionClass($this->arrivalEstimator);
+                $historyProperty = $reflection->getProperty('history');
+                $historyProperty->setValue($this->arrivalEstimator, $history);
+            }
+        }
+
+        // Verify warm-up actually reached 12
+        expect($target)->toBe(12);
+
+        // Now pending drops to 0 — Little's Law gives ~7, well below the previous 12
+        $history = $this->arrivalEstimator->getHistory();
+        if (! empty($history)) {
+            $key = array_key_first($history);
+            foreach ($history[$key] as &$snapshot) {
+                $snapshot['timestamp'] -= 5;
+            }
+            unset($snapshot);
+
+            $reflection = new ReflectionClass($this->arrivalEstimator);
+            $historyProperty = $reflection->getProperty('history');
+            $historyProperty->setValue($this->arrivalEstimator, $history);
+        }
+
+        $dropMetrics = createMetrics([
+            'throughput_per_minute' => 1440.0,
+            'active_workers' => 12,
+            'pending' => 0,
+            'oldest_job_age' => 0,
+            'avg_duration' => 0.28,
+        ]);
+
+        $target = $this->strategy->calculateTargetWorkers($dropMetrics, $config);
+        $reason = $this->strategy->getLastReason();
+
+        // Target should be dampened: strategy wants ~7, smoother limits to 11
+        expect($target)->toBeGreaterThanOrEqual(11)
+            ->and($reason)->toContain('dampened');
+    });
+});

--- a/tests/Unit/Scaling/Calculators/TargetSmootherTest.php
+++ b/tests/Unit/Scaling/Calculators/TargetSmootherTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Scaling\Calculators\TargetSmoother;
+
+beforeEach(function () {
+    $this->smoother = new TargetSmoother;
+});
+
+describe('first call behaviour', function () {
+    it('returns raw target on first call', function () {
+        $result = $this->smoother->smooth('redis:default', 8, 1440.0);
+
+        expect($result)->toBe(8);
+    });
+
+    it('reports no smoothing applied on first call', function () {
+        $this->smoother->smooth('redis:default', 8, 1440.0);
+
+        $info = $this->smoother->getLastSmoothing();
+        expect($info['applied'])->toBeFalse();
+    });
+});
+
+describe('scale-up is unrestricted', function () {
+    it('allows immediate scale-up regardless of throughput stability', function () {
+        // Build stable throughput history
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 8, 1440.0);
+        }
+
+        // Large scale-up: 8 → 12
+        $result = $this->smoother->smooth('redis:default', 12, 1440.0);
+
+        expect($result)->toBe(12);
+    });
+
+    it('does not apply smoothing on scale-up', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 8, 1440.0);
+        }
+
+        $this->smoother->smooth('redis:default', 12, 1440.0);
+
+        expect($this->smoother->getLastSmoothing()['applied'])->toBeFalse();
+    });
+});
+
+describe('scale-down with stable throughput', function () {
+    it('limits scale-down to 1 worker per cycle when throughput is stable', function () {
+        // Build stable throughput history at target=12
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, 1440.0);
+        }
+
+        // Strategy wants to drop to 8 (4 worker drop)
+        $result = $this->smoother->smooth('redis:default', 8, 1440.0);
+
+        // Should only drop by 1: 12 → 11
+        expect($result)->toBe(11);
+    });
+
+    it('reports smoothing was applied', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, 1440.0);
+        }
+
+        $this->smoother->smooth('redis:default', 8, 1440.0);
+        $info = $this->smoother->getLastSmoothing();
+
+        expect($info['applied'])->toBeTrue()
+            ->and($info['raw_target'])->toBe(8)
+            ->and($info['smoothed_target'])->toBe(11)
+            ->and($info['stable'])->toBeTrue();
+    });
+
+    it('allows gradual scale-down over multiple cycles', function () {
+        // Build stable throughput history at target=12
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, 1440.0);
+        }
+
+        // Each cycle: strategy wants 8, smoother allows -1 each time
+        $targets = [];
+        for ($i = 0; $i < 5; $i++) {
+            $targets[] = $this->smoother->smooth('redis:default', 8, 1440.0);
+        }
+
+        // Should step down gradually: 11, 10, 9, 8, 8
+        expect($targets)->toBe([11, 10, 9, 8, 8]);
+    });
+
+    it('does not overshoot below the raw target', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 10, 1440.0);
+        }
+
+        // Strategy wants 9 (only 1 less) — smoothing should allow it directly
+        $result = $this->smoother->smooth('redis:default', 9, 1440.0);
+
+        expect($result)->toBe(9);
+        expect($this->smoother->getLastSmoothing()['applied'])->toBeFalse();
+    });
+});
+
+describe('scale-down with volatile throughput', function () {
+    it('allows full scale-down when throughput varies significantly', function () {
+        // Build volatile throughput history: swings between 800 and 1600
+        $this->smoother->smooth('redis:default', 12, 800.0);
+        $this->smoother->smooth('redis:default', 12, 1600.0);
+        $this->smoother->smooth('redis:default', 12, 800.0);
+        $this->smoother->smooth('redis:default', 12, 1600.0);
+        $this->smoother->smooth('redis:default', 12, 800.0);
+
+        // Strategy wants to drop to 6
+        $result = $this->smoother->smooth('redis:default', 6, 1600.0);
+
+        // Throughput CV is high → allow full drop
+        expect($result)->toBe(6);
+    });
+
+    it('allows full scale-down with insufficient history', function () {
+        // Only 1 warm-up sample — the scale-down call adds a 2nd, still below minimum of 3
+        $this->smoother->smooth('redis:default', 12, 1440.0);
+
+        // Strategy wants to drop to 8
+        $result = $this->smoother->smooth('redis:default', 8, 1440.0);
+
+        // Not enough history to determine stability → allow full drop
+        expect($result)->toBe(8);
+    });
+});
+
+describe('per-queue isolation', function () {
+    it('tracks state independently per queue', function () {
+        // Build stable history for queue A at target=12
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:queue-a', 12, 1440.0);
+        }
+
+        // Queue B has no history
+        $resultB = $this->smoother->smooth('redis:queue-b', 5, 1440.0);
+
+        // Queue B should not be affected by queue A's history
+        expect($resultB)->toBe(5);
+    });
+
+    it('smooths each queue independently', function () {
+        // Build stable history for both queues
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:queue-a', 12, 1440.0);
+            $this->smoother->smooth('redis:queue-b', 8, 1440.0);
+        }
+
+        // Both want to drop
+        $resultA = $this->smoother->smooth('redis:queue-a', 6, 1440.0);
+        $resultB = $this->smoother->smooth('redis:queue-b', 4, 1440.0);
+
+        expect($resultA)->toBe(11) // 12 - 1
+            ->and($resultB)->toBe(7); // 8 - 1
+    });
+});
+
+describe('reset', function () {
+    it('clears all state on full reset', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, 1440.0);
+        }
+
+        $this->smoother->reset();
+
+        // After reset, no previous target → allows full drop
+        $result = $this->smoother->smooth('redis:default', 5, 1440.0);
+        expect($result)->toBe(5);
+    });
+
+    it('clears state for specific queue only', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:queue-a', 12, 1440.0);
+            $this->smoother->smooth('redis:queue-b', 10, 1440.0);
+        }
+
+        $this->smoother->reset('redis:queue-a');
+
+        // Queue A reset: allows full drop
+        $resultA = $this->smoother->smooth('redis:queue-a', 5, 1440.0);
+        expect($resultA)->toBe(5);
+
+        // Queue B still has history: limits drop
+        $resultB = $this->smoother->smooth('redis:queue-b', 5, 1440.0);
+        expect($resultB)->toBe(9);
+    });
+});
+
+describe('coefficient of variation diagnostics', function () {
+    it('reports CV in last smoothing info', function () {
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, 1440.0);
+        }
+
+        $this->smoother->smooth('redis:default', 8, 1440.0);
+        $info = $this->smoother->getLastSmoothing();
+
+        // Perfectly stable throughput should have CV = 0
+        expect($info['cv'])->toBe(0.0)
+            ->and($info['stable'])->toBeTrue();
+    });
+
+    it('reports null CV when insufficient samples', function () {
+        $this->smoother->smooth('redis:default', 12, 1440.0);
+        $this->smoother->smooth('redis:default', 8, 1440.0);
+
+        $info = $this->smoother->getLastSmoothing();
+
+        expect($info['cv'])->toBeNull()
+            ->and($info['stable'])->toBeFalse();
+    });
+});
+
+describe('steady-state oscillation prevention', function () {
+    it('holds target stable across 30 cycles with alternating pending-like inputs', function () {
+        // Simulate: strategy alternates between wanting 12 and 8 workers
+        // due to pending oscillating between 0 and 25. Throughput is constant.
+        $equilibrium = 12;
+        $throughput = 1440.0;
+
+        // Warm-up: establish stable throughput at equilibrium
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', $equilibrium, $throughput);
+        }
+
+        // 30 cycles of oscillation: strategy alternates between 12 and 8
+        $targets = [];
+        for ($cycle = 0; $cycle < 30; $cycle++) {
+            $rawTarget = ($cycle % 2 === 0) ? 8 : 12;
+            $targets[] = $this->smoother->smooth('redis:default', $rawTarget, $throughput);
+        }
+
+        // Assert all targets stay within ±1 of equilibrium
+        foreach ($targets as $i => $target) {
+            expect($target)->toBeGreaterThanOrEqual($equilibrium - 1, "Cycle {$i}: target {$target} dropped below ".($equilibrium - 1))
+                ->and($target)->toBeLessThanOrEqual($equilibrium, "Cycle {$i}: target {$target} exceeded {$equilibrium}");
+        }
+    });
+
+    it('never drops more than 1 worker per cycle under stable throughput', function () {
+        $throughput = 1440.0;
+
+        // Warm-up at target=12
+        for ($i = 0; $i < 5; $i++) {
+            $this->smoother->smooth('redis:default', 12, $throughput);
+        }
+
+        // Simulate 20 cycles of consistent scale-down pressure
+        $previousTarget = 12;
+        for ($cycle = 0; $cycle < 20; $cycle++) {
+            $target = $this->smoother->smooth('redis:default', 4, $throughput);
+            $drop = $previousTarget - $target;
+
+            expect($drop)->toBeLessThanOrEqual(1, "Cycle {$cycle}: dropped {$drop} workers (from {$previousTarget} to {$target})");
+
+            $previousTarget = $target;
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #15 — target oscillates by 33%+ at the edge of stable load due to missing hysteresis between scale-up and scale-down.

- Adds `TargetSmoother` calculator that tracks per-queue throughput stability and limits scale-down to **-1 worker per cycle** when throughput coefficient of variation is below 5%
- Integrates smoothing into `HybridStrategy` after target clamping, so it applies in both single-host and cluster mode (where policies are bypassed)
- Scale-up remains unrestricted to preserve reactivity to genuine load increases

## Root cause

When pending momentarily drops to 0 under steady-state load, `BacklogDrainCalculator` returns 0 and `LittlesLawCalculator` alone produces ~7 workers (vs the 12 needed). The strategy drops target sharply, then when pending refills the backlog drain pushes it right back up. Throughput never changes — the oscillation is entirely an artifact of instantaneous backlog sampling.

## How the fix works

`TargetSmoother` maintains a rolling window of 10 throughput samples per queue. When the coefficient of variation (CV) is below 5%, throughput is considered stable and scale-down is rate-limited to at most 1 worker per cycle. This absorbs transient pending=0 blips without affecting scale-up speed or response to genuine load drops (where throughput actually changes).

## Test plan

- [x] 18 unit tests for `TargetSmoother` covering: first-call behavior, unrestricted scale-up, stable/volatile throughput detection, per-queue isolation, reset, CV diagnostics, and 30-cycle oscillation prevention
- [x] 3 integration tests in `HybridStrategyBehaviourTest` verifying: target stability with alternating pending, scale-up reactivity with load spikes, and dampening reason in output
- [x] All 501 existing tests pass (no regressions)
- [x] Pint clean, no new PHPStan errors
