### PR TITLE
feat: add fair-share allocation between queues

### DIFF
--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -27,6 +27,7 @@ use Cbox\LaravelQueueAutoscale\Output\DataTransferObjects\QueueStats;
 use Cbox\LaravelQueueAutoscale\Output\DataTransferObjects\WorkerStatus;
 use Cbox\LaravelQueueAutoscale\Policies\PolicyExecutor;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\CapacityCalculator;
+use Cbox\LaravelQueueAutoscale\Scaling\FairShareAllocator;
 use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
 use Cbox\LaravelQueueAutoscale\Scaling\ScalingEngine;
 use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
@@ -370,7 +371,12 @@ final class AutoscaleManager
         $assignedTotals = array_fill_keys($managerIds, 0);
         $assignments = array_fill_keys($managerIds, []);
         $clusterTotalWorkers = array_sum(array_map(static fn (ClusterManagerState $state): int => $state->totalWorkers, $activeManagers));
-        $workloads = [];
+        $clusterCapacity = array_sum(array_map(static fn (ClusterManagerState $state): int => $state->maxWorkers, $activeManagers));
+
+        // Phase A: Collect demands for all workloads
+        $demands = [];
+        $workerConfigs = [];
+        $workloadMeta = [];
 
         foreach ($metricsByKey as $queueKey => $metrics) {
             if (AutoscaleConfiguration::isExcluded($metrics->queue) || isset($groupedQueueKeys[$queueKey])) {
@@ -380,32 +386,20 @@ final class AutoscaleManager
             $config = QueueConfiguration::fromConfig($metrics->connection, $metrics->queue);
             $workloadKey = ClusterRecommendation::queueWorkloadKey($metrics->connection, $metrics->queue);
             $currentWorkers = $this->clusterCurrentWorkers($activeManagers, $workloadKey);
-
             $targetWorkers = $this->clusterTargetWorkers($config, $metrics, $currentWorkers, $clusterTotalWorkers);
-            $workloadAssignments = $this->distributeClusterTarget($activeManagers, $workloadKey, $targetWorkers, $assignedTotals);
 
-            foreach ($workloadAssignments as $managerId => $target) {
-                $assignments[$managerId][$workloadKey] = $target;
-            }
-
-            $workloads[] = [
+            $demands[$workloadKey] = $targetWorkers;
+            $workerConfigs[$workloadKey] = ['min' => $config->workers->min, 'max' => $config->workers->max];
+            $workloadMeta[$workloadKey] = [
                 'type' => 'queue',
                 'connection' => $metrics->connection,
                 'name' => $metrics->queue,
                 'driver' => $metrics->driver,
+                'config' => $config,
                 'current_workers' => $currentWorkers,
-                'target_workers' => $targetWorkers,
-                'worker_min' => $config->workers->min,
-                'worker_max' => $config->workers->max,
-                'sla_target_seconds' => $config->sla->targetSeconds,
-                'pending' => $metrics->pending,
-                'oldest_job_age' => $metrics->oldestJobAge,
-                'oldest_job_age_status' => $metrics->ageStatus,
-                'throughput_per_minute' => $metrics->throughputPerMinute,
-                'active_workers' => $metrics->activeWorkers,
-                'utilization_percent' => round($metrics->utilizationRate, 1),
+                'metrics' => $metrics,
+                'scalable' => $config->workers->scalable,
                 'member_queues' => [$metrics->queue],
-                'action' => $targetWorkers <=> $currentWorkers,
             ];
         }
 
@@ -415,6 +409,46 @@ final class AutoscaleManager
             $workloadKey = ClusterRecommendation::groupWorkloadKey($group->connection, $group->name);
             $currentWorkers = $this->clusterCurrentWorkers($activeManagers, $workloadKey);
             $targetWorkers = $this->clusterTargetWorkers($config, $aggregated, $currentWorkers, $clusterTotalWorkers);
+
+            $demands[$workloadKey] = $targetWorkers;
+            $workerConfigs[$workloadKey] = ['min' => $config->workers->min, 'max' => $config->workers->max];
+            $workloadMeta[$workloadKey] = [
+                'type' => 'group',
+                'connection' => $group->connection,
+                'name' => $group->name,
+                'driver' => $aggregated->driver,
+                'config' => $config,
+                'current_workers' => $currentWorkers,
+                'metrics' => $aggregated,
+                'scalable' => $config->workers->scalable,
+                'member_queues' => array_values($group->queues),
+            ];
+        }
+
+        // Phase B: Fair-share allocation
+        $pinnedDemands = [];
+        $scalableDemands = [];
+        $scalableConfigs = [];
+
+        foreach ($demands as $workloadKey => $demand) {
+            if (! $workloadMeta[$workloadKey]['scalable']) {
+                $pinnedDemands[$workloadKey] = $demand;
+            } else {
+                $scalableDemands[$workloadKey] = $demand;
+                $scalableConfigs[$workloadKey] = $workerConfigs[$workloadKey];
+            }
+        }
+
+        $scalableCapacity = max($clusterCapacity - array_sum($pinnedDemands), 0);
+        $allocator = new FairShareAllocator;
+        $scalableTargets = $allocator->allocate($scalableDemands, $scalableConfigs, $scalableCapacity);
+        $adjustedTargets = $pinnedDemands + $scalableTargets;
+
+        // Phase C: Distribute adjusted targets across hosts and build workload summaries
+        $workloads = [];
+
+        foreach ($adjustedTargets as $workloadKey => $targetWorkers) {
+            $meta = $workloadMeta[$workloadKey];
             $workloadAssignments = $this->distributeClusterTarget($activeManagers, $workloadKey, $targetWorkers, $assignedTotals);
 
             foreach ($workloadAssignments as $managerId => $target) {
@@ -422,23 +456,23 @@ final class AutoscaleManager
             }
 
             $workloads[] = [
-                'type' => 'group',
-                'connection' => $group->connection,
-                'name' => $group->name,
-                'driver' => $aggregated->driver,
-                'current_workers' => $currentWorkers,
+                'type' => $meta['type'],
+                'connection' => $meta['connection'],
+                'name' => $meta['name'],
+                'driver' => $meta['driver'],
+                'current_workers' => $meta['current_workers'],
                 'target_workers' => $targetWorkers,
-                'worker_min' => $config->workers->min,
-                'worker_max' => $config->workers->max,
-                'sla_target_seconds' => $config->sla->targetSeconds,
-                'pending' => $aggregated->pending,
-                'oldest_job_age' => $aggregated->oldestJobAge,
-                'oldest_job_age_status' => $aggregated->ageStatus,
-                'throughput_per_minute' => $aggregated->throughputPerMinute,
-                'active_workers' => $aggregated->activeWorkers,
-                'utilization_percent' => round($aggregated->utilizationRate, 1),
-                'member_queues' => array_values($group->queues),
-                'action' => $targetWorkers <=> $currentWorkers,
+                'worker_min' => $meta['config']->workers->min,
+                'worker_max' => $meta['config']->workers->max,
+                'sla_target_seconds' => $meta['config']->sla->targetSeconds,
+                'pending' => $meta['metrics']->pending,
+                'oldest_job_age' => $meta['metrics']->oldestJobAge,
+                'oldest_job_age_status' => $meta['metrics']->ageStatus,
+                'throughput_per_minute' => $meta['metrics']->throughputPerMinute,
+                'active_workers' => $meta['metrics']->activeWorkers,
+                'utilization_percent' => round($meta['metrics']->utilizationRate, 1),
+                'member_queues' => $meta['member_queues'],
+                'action' => $targetWorkers <=> $meta['current_workers'],
             ];
         }
 

--- a/src/Scaling/FairShareAllocator.php
+++ b/src/Scaling/FairShareAllocator.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Scaling;
+
+final class FairShareAllocator
+{
+    /**
+     * Distribute cluster capacity fairly across workloads.
+     *
+     * When total demand fits within capacity, returns demands unchanged.
+     * When demand exceeds capacity, allocates mins first then distributes
+     * remaining capacity proportionally to each workload's headroom,
+     * with water-filling iteration to reclaim capacity freed by max clamping.
+     *
+     * @param  array<string, int>  $demands  workloadKey => raw demand from evaluateDemand()
+     * @param  array<string, array{min: int, max: int}>  $configs  workloadKey => worker bounds
+     * @param  int  $clusterCapacity  total capacity available for scalable workloads
+     * @return array<string, int> workloadKey => adjusted target
+     */
+    public function allocate(array $demands, array $configs, int $clusterCapacity): array
+    {
+        if ($demands === []) {
+            return [];
+        }
+
+        $totalDemand = array_sum($demands);
+
+        if ($totalDemand <= $clusterCapacity) {
+            return $demands;
+        }
+
+        return $this->allocateWithFairShare($demands, $configs, $clusterCapacity);
+    }
+
+    /**
+     * @param  array<string, int>  $demands
+     * @param  array<string, array{min: int, max: int}>  $configs
+     * @return array<string, int>
+     */
+    private function allocateWithFairShare(array $demands, array $configs, int $clusterCapacity): array
+    {
+        // Phase 1: guarantee every workload gets its min
+        $targets = [];
+
+        foreach ($demands as $key => $demand) {
+            $targets[$key] = $configs[$key]['min'];
+        }
+
+        $remainingCapacity = $clusterCapacity - array_sum($targets);
+
+        if ($remainingCapacity <= 0) {
+            return $targets;
+        }
+
+        // Phase 2: distribute remaining proportionally with water-filling
+        $this->waterFill($targets, $demands, $configs, $clusterCapacity);
+
+        return $targets;
+    }
+
+    /**
+     * @param  array<string, int>  $targets
+     * @param  array<string, int>  $demands
+     * @param  array<string, array{min: int, max: int}>  $configs
+     */
+    private function waterFill(array &$targets, array $demands, array $configs, int $clusterCapacity): void
+    {
+        $maxIterations = count($demands) + 1;
+
+        for ($iteration = 0; $iteration < $maxIterations; $iteration++) {
+            $remaining = $clusterCapacity - array_sum($targets);
+
+            if ($remaining <= 0) {
+                break;
+            }
+
+            $eligible = [];
+
+            foreach ($demands as $key => $demand) {
+                $ceiling = min($demand, $configs[$key]['max']);
+
+                if ($targets[$key] < $ceiling) {
+                    $eligible[$key] = $ceiling - $targets[$key];
+                }
+            }
+
+            if ($eligible === []) {
+                break;
+            }
+
+            $totalHeadroom = array_sum($eligible);
+
+            if ($totalHeadroom <= 0) {
+                break;
+            }
+
+            // Proportional distribution with largest-remainder
+            $fractionals = [];
+
+            foreach ($eligible as $key => $headroom) {
+                $share = $headroom * ($remaining / $totalHeadroom);
+                $targets[$key] += (int) floor($share);
+                $fractionals[$key] = $share - floor($share);
+            }
+
+            // Distribute leftover to highest fractional remainders
+            $leftover = $clusterCapacity - array_sum($targets);
+
+            if ($leftover > 0) {
+                $this->distributeFractionalLeftover($targets, $fractionals, $configs, $demands, $leftover);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, int>  $targets
+     * @param  array<string, float>  $fractionals
+     * @param  array<string, array{min: int, max: int}>  $configs
+     * @param  array<string, int>  $demands
+     */
+    private function distributeFractionalLeftover(
+        array &$targets,
+        array $fractionals,
+        array $configs,
+        array $demands,
+        int $leftover,
+    ): void {
+        // Sort by fractional descending, tie-break by key ascending (deterministic)
+        uksort($fractionals, function (string $a, string $b) use ($fractionals): int {
+            $cmp = $fractionals[$b] <=> $fractionals[$a];
+
+            return $cmp !== 0 ? $cmp : strcmp($a, $b);
+        });
+
+        foreach ($fractionals as $key => $frac) {
+            if ($leftover <= 0) {
+                break;
+            }
+
+            $ceiling = min($demands[$key], $configs[$key]['max']);
+
+            if ($targets[$key] < $ceiling) {
+                $targets[$key]++;
+                $leftover--;
+            }
+        }
+    }
+}

--- a/src/Scaling/FairShareAllocator.php
+++ b/src/Scaling/FairShareAllocator.php
@@ -82,7 +82,11 @@ final class FairShareAllocator
                 $ceiling = min($demand, $configs[$key]['max']);
 
                 if ($targets[$key] < $ceiling) {
-                    $eligible[$key] = $ceiling - $targets[$key];
+                    // Use uncapped headroom for proportional distribution.
+                    // This may over-allocate past max in this iteration;
+                    // the clamping step below corrects it, and the freed
+                    // capacity is picked up by the next iteration.
+                    $eligible[$key] = $demand - $targets[$key];
                 }
             }
 
@@ -110,6 +114,13 @@ final class FairShareAllocator
 
             if ($leftover > 0) {
                 $this->distributeFractionalLeftover($targets, $fractionals, $configs, $demands, $leftover);
+            }
+
+            // Clamp to ceiling — capacity freed by clamping is picked
+            // up by the next water-fill iteration
+            foreach ($targets as $key => $target) {
+                $ceiling = min($demands[$key], $configs[$key]['max']);
+                $targets[$key] = min($target, $ceiling);
             }
         }
     }

--- a/tests/Unit/Cluster/ClusterFairShareIntegrationTest.php
+++ b/tests/Unit/Cluster/ClusterFairShareIntegrationTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterManagerState;
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
+use Cbox\LaravelQueueAutoscale\Scaling\FairShareAllocator;
+
+/**
+ * Create a minimal ClusterManagerState for distribution tests.
+ */
+function makeFairShareManagerState(string $id, int $maxWorkers, int $totalWorkers = 0, array $queueWorkers = []): ClusterManagerState
+{
+    return new ClusterManagerState(
+        managerId: $id,
+        host: "host-{$id}",
+        lastSeenAt: (int) (microtime(true) * 1000),
+        totalWorkers: $totalWorkers,
+        maxWorkers: $maxWorkers,
+        availableWorkerCapacity: max($maxWorkers - $totalWorkers, 0),
+        capacityLimiter: 'cpu',
+        cpuPercent: 10.0,
+        cpuCores: 2.0,
+        cpuUsableCores: 1.8,
+        cpuReservedCores: 0.2,
+        memoryPercent: 30.0,
+        memoryTotalMb: 1024.0,
+        memoryUsedMb: 307.2,
+        memoryFreeMb: 716.8,
+        queueCount: 1,
+        groupCount: 0,
+        packageVersion: '3.4.0',
+        queueWorkers: $queueWorkers,
+        groupWorkers: [],
+    );
+}
+
+/**
+ * Invoke private distributeClusterTarget via reflection.
+ *
+ * @param  array<int, ClusterManagerState>  $managers
+ * @param  array<string, int>  $assignedTotals
+ * @return array<string, int>
+ */
+function invokeFairShareDistributeClusterTarget(array $managers, string $workloadKey, int $targetWorkers, array &$assignedTotals): array
+{
+    $manager = app(AutoscaleManager::class);
+    $method = new ReflectionMethod($manager, 'distributeClusterTarget');
+
+    return $method->invokeArgs($manager, [$managers, $workloadKey, $targetWorkers, &$assignedTotals]);
+}
+
+it('distributes fair-share targets across hosts without starvation', function () {
+    // Simulate: 4 queues each demanding 12 workers, cluster capacity 10 (2 hosts x 5)
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:fast' => 12,
+        'queue:redis:slow' => 12,
+        'queue:redis:priority' => 12,
+        'queue:redis:batch' => 12,
+    ];
+    $configs = [
+        'queue:redis:fast' => ['min' => 1, 'max' => 20],
+        'queue:redis:slow' => ['min' => 1, 'max' => 20],
+        'queue:redis:priority' => ['min' => 1, 'max' => 20],
+        'queue:redis:batch' => ['min' => 1, 'max' => 20],
+    ];
+
+    $targets = $allocator->allocate($demands, $configs, 10);
+
+    // No queue should be starved
+    foreach ($targets as $key => $target) {
+        expect($target)->toBeGreaterThanOrEqual(1, "Queue {$key} was starved");
+    }
+
+    expect(array_sum($targets))->toBe(10);
+
+    // Now distribute across 2 hosts
+    $managers = [
+        makeFairShareManagerState('host-a', maxWorkers: 5),
+        makeFairShareManagerState('host-b', maxWorkers: 5),
+    ];
+
+    $assignedTotals = ['host-a' => 0, 'host-b' => 0];
+    $allAssignments = [];
+
+    foreach ($targets as $workloadKey => $target) {
+        $distribution = invokeFairShareDistributeClusterTarget($managers, $workloadKey, $target, $assignedTotals);
+        $allAssignments[$workloadKey] = $distribution;
+    }
+
+    // Total assigned per host should not exceed host capacity
+    expect($assignedTotals['host-a'])->toBeLessThanOrEqual(5)
+        ->and($assignedTotals['host-b'])->toBeLessThanOrEqual(5);
+
+    // Total assigned across all workloads should equal the fair-share total
+    $totalAssigned = array_sum($assignedTotals);
+    expect($totalAssigned)->toBe(10);
+});
+
+it('allows idle queues to yield all capacity to busy queue in cluster', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:idle1' => 1,
+        'queue:redis:idle2' => 1,
+        'queue:redis:idle3' => 1,
+        'queue:redis:busy' => 50,
+    ];
+    $configs = [
+        'queue:redis:idle1' => ['min' => 1, 'max' => 10],
+        'queue:redis:idle2' => ['min' => 1, 'max' => 10],
+        'queue:redis:idle3' => ['min' => 1, 'max' => 10],
+        'queue:redis:busy' => ['min' => 1, 'max' => 100],
+    ];
+
+    $targets = $allocator->allocate($demands, $configs, 20);
+
+    // Idle queues demand exactly their min, so no contention from them
+    // Busy queue gets all remaining capacity
+    expect($targets['queue:redis:idle1'])->toBe(1)
+        ->and($targets['queue:redis:idle2'])->toBe(1)
+        ->and($targets['queue:redis:idle3'])->toBe(1)
+        ->and($targets['queue:redis:busy'])->toBe(17);
+
+    expect(array_sum($targets))->toBe(20);
+});

--- a/tests/Unit/Scaling/FairShareAllocatorTest.php
+++ b/tests/Unit/Scaling/FairShareAllocatorTest.php
@@ -224,8 +224,8 @@ it('caps at workers max and redistributes freed capacity', function () {
     $allocator = new FairShareAllocator;
 
     // A demands 15 but max=5, B demands 8 with max=20
-    // Proportional share with headroom: A headroom=4, B headroom=7, total=11
-    // A gets floor(4*8/11)=2 + min=1 = 3+1=4 via remainder, B gets floor(7*8/11)=5 + min=1 = 6
+    // Without water-filling: A=5, B=4, total=9 (1 wasted)
+    // With water-filling: A=5, B=5, total=10
     $demands = [
         'queue:redis:a' => 15,
         'queue:redis:b' => 8,
@@ -238,8 +238,8 @@ it('caps at workers max and redistributes freed capacity', function () {
     $result = $allocator->allocate($demands, $configs, 10);
 
     expect($result)->toBe([
-        'queue:redis:a' => 4,
-        'queue:redis:b' => 6,
+        'queue:redis:a' => 5,
+        'queue:redis:b' => 5,
     ]);
 });
 
@@ -247,9 +247,8 @@ it('handles multiple queues hitting max in sequence', function () {
     $allocator = new FairShareAllocator;
 
     // A max=3, B max=3, C max=20, all demand 15, capacity=10
-    // Headroom: A=2, B=2, C=14, total=18, remaining=7
-    // Proportional share: A=0.78, B=0.78, C=5.44
-    // After floor + remainder: A=2, B=2, C=6
+    // Iteration 1: uncapped proportional gives each ~3.33, A and B clamped to 3
+    // Iteration 2: freed capacity goes to C → C=4
     $demands = [
         'queue:redis:a' => 15,
         'queue:redis:b' => 15,
@@ -263,9 +262,9 @@ it('handles multiple queues hitting max in sequence', function () {
 
     $result = $allocator->allocate($demands, $configs, 10);
 
-    expect($result['queue:redis:a'])->toBe(2)
-        ->and($result['queue:redis:b'])->toBe(2)
-        ->and($result['queue:redis:c'])->toBe(6);
+    expect($result['queue:redis:a'])->toBe(3)
+        ->and($result['queue:redis:b'])->toBe(3)
+        ->and($result['queue:redis:c'])->toBe(4);
 
     expect(array_sum($result))->toBe(10);
 });

--- a/tests/Unit/Scaling/FairShareAllocatorTest.php
+++ b/tests/Unit/Scaling/FairShareAllocatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Scaling\FairShareAllocator;
+
+it('returns demands unchanged when total demand is within capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:fast' => 5,
+        'queue:redis:slow' => 3,
+    ];
+    $configs = [
+        'queue:redis:fast' => ['min' => 1, 'max' => 10],
+        'queue:redis:slow' => ['min' => 1, 'max' => 10],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe(['queue:redis:fast' => 5, 'queue:redis:slow' => 3]);
+});
+
+it('returns demands unchanged when total demand equals capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:a' => 5,
+        'queue:redis:b' => 5,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 10],
+        'queue:redis:b' => ['min' => 1, 'max' => 10],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe(['queue:redis:a' => 5, 'queue:redis:b' => 5]);
+});
+
+it('returns all zeros when all demands are zero', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:a' => 0,
+        'queue:redis:b' => 0,
+        'queue:redis:c' => 0,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 0, 'max' => 10],
+        'queue:redis:b' => ['min' => 0, 'max' => 10],
+        'queue:redis:c' => ['min' => 0, 'max' => 10],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe(['queue:redis:a' => 0, 'queue:redis:b' => 0, 'queue:redis:c' => 0]);
+});
+
+it('handles single queue demanding more than capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = ['queue:redis:only' => 20];
+    $configs = ['queue:redis:only' => ['min' => 1, 'max' => 50]];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe(['queue:redis:only' => 10]);
+});
+
+it('returns empty array when given empty inputs', function () {
+    $allocator = new FairShareAllocator;
+
+    $result = $allocator->allocate([], [], 10);
+
+    expect($result)->toBe([]);
+});

--- a/tests/Unit/Scaling/FairShareAllocatorTest.php
+++ b/tests/Unit/Scaling/FairShareAllocatorTest.php
@@ -75,3 +75,255 @@ it('returns empty array when given empty inputs', function () {
 
     expect($result)->toBe([]);
 });
+
+it('distributes proportionally when demand exceeds capacity with equal demands', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:a' => 7,
+        'queue:redis:b' => 7,
+        'queue:redis:c' => 7,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 20],
+        'queue:redis:b' => ['min' => 1, 'max' => 20],
+        'queue:redis:c' => ['min' => 1, 'max' => 20],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    // Total must equal capacity
+    expect(array_sum($result))->toBe(10);
+
+    // Each queue gets at least min
+    expect($result['queue:redis:a'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:b'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:c'])->toBeGreaterThanOrEqual(1);
+
+    // Deterministic: sorted by key, equal fractionals → a gets extra
+    // min=1 each (3 used), remaining=7, each headroom=6, share=7/3=2.33
+    // floor: 1+2=3 each (3 used + 6 = 9), leftover=1 → a gets it (highest frac, tie-break by key)
+    expect($result)->toBe([
+        'queue:redis:a' => 4,
+        'queue:redis:b' => 3,
+        'queue:redis:c' => 3,
+    ]);
+});
+
+it('distributes proportionally with unequal demands', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:high' => 20,
+        'queue:redis:low' => 5,
+    ];
+    $configs = [
+        'queue:redis:high' => ['min' => 1, 'max' => 50],
+        'queue:redis:low' => ['min' => 1, 'max' => 50],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect(array_sum($result))->toBe(10);
+    // high has 19 headroom above min, low has 4 headroom above min
+    // high gets proportionally more
+    expect($result['queue:redis:high'])->toBeGreaterThan($result['queue:redis:low']);
+});
+
+it('gives idle queue nothing and backlogged queue gets full capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:idle1' => 0,
+        'queue:redis:idle2' => 0,
+        'queue:redis:idle3' => 0,
+        'queue:redis:busy' => 20,
+    ];
+    $configs = [
+        'queue:redis:idle1' => ['min' => 0, 'max' => 10],
+        'queue:redis:idle2' => ['min' => 0, 'max' => 10],
+        'queue:redis:idle3' => ['min' => 0, 'max' => 10],
+        'queue:redis:busy' => ['min' => 0, 'max' => 50],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe([
+        'queue:redis:idle1' => 0,
+        'queue:redis:idle2' => 0,
+        'queue:redis:idle3' => 0,
+        'queue:redis:busy' => 10,
+    ]);
+});
+
+it('guarantees min workers even under heavy contention', function () {
+    $allocator = new FairShareAllocator;
+
+    // 5 queues each min=1, cluster cap 5, one queue demands 100
+    $demands = [
+        'queue:redis:a' => 1,
+        'queue:redis:b' => 1,
+        'queue:redis:c' => 1,
+        'queue:redis:d' => 1,
+        'queue:redis:hog' => 100,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 10],
+        'queue:redis:b' => ['min' => 1, 'max' => 10],
+        'queue:redis:c' => ['min' => 1, 'max' => 10],
+        'queue:redis:d' => ['min' => 1, 'max' => 10],
+        'queue:redis:hog' => ['min' => 1, 'max' => 200],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 5);
+
+    // All queues get their min
+    expect($result['queue:redis:a'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:b'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:c'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:d'])->toBeGreaterThanOrEqual(1)
+        ->and($result['queue:redis:hog'])->toBeGreaterThanOrEqual(1);
+
+    // Total does not exceed capacity
+    expect(array_sum($result))->toBeLessThanOrEqual(5);
+});
+
+it('returns mins even when they exceed capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    // 5 queues min=3 each, capacity=10 — mins alone = 15 > 10
+    $demands = [
+        'queue:redis:a' => 5,
+        'queue:redis:b' => 5,
+        'queue:redis:c' => 5,
+        'queue:redis:d' => 5,
+        'queue:redis:e' => 5,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 3, 'max' => 10],
+        'queue:redis:b' => ['min' => 3, 'max' => 10],
+        'queue:redis:c' => ['min' => 3, 'max' => 10],
+        'queue:redis:d' => ['min' => 3, 'max' => 10],
+        'queue:redis:e' => ['min' => 3, 'max' => 10],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    // Each queue gets exactly its min — mins are hard guarantees
+    expect($result['queue:redis:a'])->toBe(3)
+        ->and($result['queue:redis:b'])->toBe(3)
+        ->and($result['queue:redis:c'])->toBe(3)
+        ->and($result['queue:redis:d'])->toBe(3)
+        ->and($result['queue:redis:e'])->toBe(3);
+
+    // Total exceeds capacity — cluster is undersized, scale signal will flag it
+    expect(array_sum($result))->toBe(15);
+});
+
+it('caps at workers max and redistributes freed capacity', function () {
+    $allocator = new FairShareAllocator;
+
+    // A demands 15 but max=5, B demands 8 with max=20
+    // Proportional share with headroom: A headroom=4, B headroom=7, total=11
+    // A gets floor(4*8/11)=2 + min=1 = 3+1=4 via remainder, B gets floor(7*8/11)=5 + min=1 = 6
+    $demands = [
+        'queue:redis:a' => 15,
+        'queue:redis:b' => 8,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 5],
+        'queue:redis:b' => ['min' => 1, 'max' => 20],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result)->toBe([
+        'queue:redis:a' => 4,
+        'queue:redis:b' => 6,
+    ]);
+});
+
+it('handles multiple queues hitting max in sequence', function () {
+    $allocator = new FairShareAllocator;
+
+    // A max=3, B max=3, C max=20, all demand 15, capacity=10
+    // Headroom: A=2, B=2, C=14, total=18, remaining=7
+    // Proportional share: A=0.78, B=0.78, C=5.44
+    // After floor + remainder: A=2, B=2, C=6
+    $demands = [
+        'queue:redis:a' => 15,
+        'queue:redis:b' => 15,
+        'queue:redis:c' => 15,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 3],
+        'queue:redis:b' => ['min' => 1, 'max' => 3],
+        'queue:redis:c' => ['min' => 1, 'max' => 20],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result['queue:redis:a'])->toBe(2)
+        ->and($result['queue:redis:b'])->toBe(2)
+        ->and($result['queue:redis:c'])->toBe(6);
+
+    expect(array_sum($result))->toBe(10);
+});
+
+it('does not exceed demand even when capacity is available', function () {
+    $allocator = new FairShareAllocator;
+
+    // A demands 3, B demands 15, capacity=10
+    // Headroom: A=2 (demand 3 - min 1), B=14 (demand 15 - min 1), total=16, remaining=8
+    // Proportional: A share=2*(8/16)=1, B share=14*(8/16)=7 → A=2, B=8
+    $demands = [
+        'queue:redis:a' => 3,
+        'queue:redis:b' => 15,
+    ];
+    $configs = [
+        'queue:redis:a' => ['min' => 1, 'max' => 20],
+        'queue:redis:b' => ['min' => 1, 'max' => 20],
+    ];
+
+    $result = $allocator->allocate($demands, $configs, 10);
+
+    expect($result['queue:redis:a'])->toBe(2)
+        ->and($result['queue:redis:b'])->toBe(8);
+
+    expect(array_sum($result))->toBe(10);
+});
+
+it('produces deterministic results regardless of input order', function () {
+    $allocator = new FairShareAllocator;
+
+    $demands = [
+        'queue:redis:z' => 7,
+        'queue:redis:a' => 7,
+        'queue:redis:m' => 7,
+    ];
+    $configs = [
+        'queue:redis:z' => ['min' => 1, 'max' => 20],
+        'queue:redis:a' => ['min' => 1, 'max' => 20],
+        'queue:redis:m' => ['min' => 1, 'max' => 20],
+    ];
+
+    $result1 = $allocator->allocate($demands, $configs, 10);
+
+    // Reverse input order
+    $demandsReversed = array_reverse($demands, true);
+    $configsReversed = array_reverse($configs, true);
+    $result2 = $allocator->allocate($demandsReversed, $configsReversed, 10);
+
+    // Both should produce identical results
+    ksort($result1);
+    ksort($result2);
+    expect($result1)->toBe($result2);
+
+    // Total must equal capacity
+    expect(array_sum($result1))->toBe(10);
+
+    // Tie-break by key ascending: 'a' gets the extra worker
+    expect($result1['queue:redis:a'])->toBe(4)
+        ->and($result1['queue:redis:m'])->toBe(3)
+        ->and($result1['queue:redis:z'])->toBe(3);
+});


### PR DESCRIPTION
## Summary

Adds a fairness layer between per-queue demand evaluation and cross-host distribution, resolving the first-queue-wins starvation problem when total demand exceeds cluster capacity.

- New `FairShareAllocator` class: min-first then proportional allocation with water-filling iteration to reclaim capacity freed by max clamping
- Refactored `evaluateAndPublishClusterRecommendations()` from single evaluate-and-distribute loop into three phases: collect demands → fair-share allocate → distribute adjusted targets
- Pinned (non-scalable) workloads bypass the allocator and subtract from available capacity
- No new configuration keys — `workers.max` remains a safety bound, not a fairness mechanism
- 16 new tests (14 unit + 2 integration), all 496 tests passing

### Key behaviors

- **No contention → no change**: if `sum(demand) <= capacity`, every queue gets exactly what it asked for
- **Mins guaranteed**: every queue gets at least `workers.min`, even under pressure
- **Idle queues yield**: capacity flows to queues that need it
- **Max as safety bound**: proportional distribution + water-filling ensures max clamping doesn't waste capacity
- **Deterministic**: tie-breaking by workload key ensures stable, reproducible allocations

Closes #16

## Test plan

- [x] No contention returns demands unchanged
- [x] Equal contention distributes proportionally with largest-remainder
- [x] Min guarantees hold even when mins exceed capacity
- [x] Idle queues yield all capacity to busy queues
- [x] Max clamping redistributes freed capacity via water-filling
- [x] Multiple queues hitting max in sequence converge correctly
- [x] Deterministic results regardless of input order
- [x] Fair-share + distributeClusterTarget integration (multi-host)
- [x] Full test suite passes (496 tests, 1241 assertions)
- [x] PHPStan clean (1 pre-existing unrelated error)
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)