### PR TITLE
Add autoscale restart deploy signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `laravel-queue-autoscale` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.7.0 — Deployment-safe autoscale restarts - 2026-06-04
+
+### Added
+
+- **Deployment-safe `queue:autoscale:restart` signal** — The restart command now writes a global, deployment-stable cache signal so deploy hooks can ask the running autoscale manager to drain spawned workers and exit. The process supervisor then restarts `queue:autoscale` from the current release. (#27)
+- **`manager.restart_scope` config key** (env: `QUEUE_AUTOSCALE_RESTART_SCOPE`) — Optional cache-scope override for installs where multiple apps share the same cache backend and need isolated autoscale restart signals.
+
+### Changed
+
+- **Restart signal compatibility preserved** — Managers now check both the new deployment-stable restart key and the legacy manager-scoped key, so existing restart signals remain compatible during upgrades.
+- **Deployment documentation now prefers Artisan restarts** — Forge, Ploi, self-hosted, installation, README, and troubleshooting docs now recommend `php artisan queue:autoscale:restart` for deploy hooks, with direct `supervisorctl` / `systemctl` restarts documented as operational fallbacks only.
+
+### Testing
+
+- Added coverage for restart signal scoping, legacy signal compatibility, command signal writes, and manager shutdown/drain behavior after a restart request.
+
+**Full Changelog**: https://github.com/cboxdk/laravel-queue-autoscale/compare/v3.6.3...v3.7.0
+
 ## v3.6.3 — Cluster scale-up signal & cumulative decision history - 2026-05-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -432,6 +432,12 @@ redirect_stderr=true
 stdout_logfile=/path/to/logs/autoscale.log
 ```
 
+On deploy, restart the manager through Artisan so it can drain workers before Supervisor starts it again from the new release:
+
+```bash
+php artisan queue:autoscale:restart
+```
+
 ### Custom Evaluation Interval
 
 ```bash

--- a/config/queue-autoscale.php
+++ b/config/queue-autoscale.php
@@ -182,10 +182,15 @@ return [
     |--------------------------------------------------------------------------
     | Manager process
     |--------------------------------------------------------------------------
+    |
+    | restart_scope controls the cache key used by queue:autoscale:restart.
+    | Leave unset unless multiple apps share the same cache backend.
+    |
     */
     'manager' => [
         'evaluation_interval_seconds' => 5,
         'log_channel' => env('QUEUE_AUTOSCALE_LOG_CHANNEL', 'stack'),
+        'restart_scope' => env('QUEUE_AUTOSCALE_RESTART_SCOPE'),
     ],
 
     /*

--- a/docs/advanced-usage/deployment.md
+++ b/docs/advanced-usage/deployment.md
@@ -440,7 +440,10 @@ tail -f storage/logs/laravel.log | grep "WorkersScaled"
 # Status check
 sudo supervisorctl status queue-autoscale
 
-# Restart if needed
+# Graceful restart on deploy
+php artisan queue:autoscale:restart
+
+# Force restart if the manager is wedged
 sudo supervisorctl restart queue-autoscale
 
 # View recent logs

--- a/docs/basic-usage/configuration.md
+++ b/docs/basic-usage/configuration.md
@@ -340,12 +340,13 @@ Balance based on:
 
 ```php
 'manager' => [
-    'evaluation_interval_seconds' => 30,
-    'max_concurrent_evaluations' => 5,    // Parallel queue evaluations
-    'enable_metrics_collection' => true,  // Collect performance data
-    'metrics_retention_hours' => 24,      // How long to keep metrics
+    'evaluation_interval_seconds' => 5,
+    'log_channel' => env('QUEUE_AUTOSCALE_LOG_CHANNEL', 'stack'),
+    'restart_scope' => env('QUEUE_AUTOSCALE_RESTART_SCOPE'),
 ],
 ```
+
+`restart_scope` controls the cache key used by `php artisan queue:autoscale:restart`. Leave it unset for the default `app.name` + `app.env` scope. Set `QUEUE_AUTOSCALE_RESTART_SCOPE` when multiple apps share the same cache backend and need isolated restart signals.
 
 ## Advanced Options
 
@@ -437,6 +438,10 @@ QUEUE_AUTOSCALE_ENABLED=true
 # Optional explicit manager/node ID override.
 # Leave unset to use the built-in auto-generated node identity.
 QUEUE_AUTOSCALE_MANAGER_ID=web-01
+
+# Optional cache scope for php artisan queue:autoscale:restart.
+# Set this if multiple apps share the same cache backend.
+QUEUE_AUTOSCALE_RESTART_SCOPE=my-app-production
 
 # Optional signal backends.
 # auto => null/no-op on single host, Redis-backed in cluster mode

--- a/docs/basic-usage/troubleshooting.md
+++ b/docs/basic-usage/troubleshooting.md
@@ -133,9 +133,13 @@ If neither applies, run `queue:autoscale:debug` for each member queue. If the me
 
 The manager is a long-running process — it holds the config in memory. It does not re-read the file.
 
-**Fix:** restart the manager. Every [platform deployment guide](../deployment/_index.md) covers the correct restart command, including `php artisan queue:autoscale:restart` for deploy hooks that cannot call `systemctl` / `supervisorctl` directly.
+**Fix:** restart the manager. Every [platform deployment guide](../deployment/_index.md) covers the preferred deployment command:
 
-If you're on Forge/Ploi, the zero-downtime deploy flow restarts the daemon automatically. If you skip that step in a custom deploy script, add `sudo supervisorctl restart daemon-<id>` (or the systemd equivalent).
+```bash
+php artisan queue:autoscale:restart
+```
+
+It lets the running manager drain spawned workers and exit. Your platform supervisor then starts the manager again from the current release. Use `supervisorctl restart` or `systemctl restart` only as manual fallbacks if the process is wedged.
 
 ## Two autoscalers are fighting each other
 

--- a/docs/deployment/_index.md
+++ b/docs/deployment/_index.md
@@ -20,7 +20,7 @@ The autoscaler manager (`php artisan queue:autoscale`) is a long-running daemon.
 - **Single-node or cluster mode.** By default, run one autoscaler. If you enable `queue-autoscale.cluster.enabled`, multiple managers can safely run against the same queues: they auto-join via Redis, elect a leader, and receive per-host worker recommendations.
 - **Graceful shutdown.** The manager catches `SIGTERM` and cleanly stops all spawned workers. Your platform should send SIGTERM, wait for `shutdown_timeout_seconds` (default 30), then SIGKILL.
 - **Don't double-configure workers.** If your platform has a "queue workers" section (Forge, Ploi) **do not** add entries for queues the autoscaler manages. The autoscaler IS your queue worker supervisor — the platform UI is for `queue:work` daemons that the autoscaler would fight with.
-- **Restart on deploy.** When your code changes, the manager must restart to pick up new config. All supported platforms do this automatically as part of the zero-downtime deploy flow, or you can signal a graceful restart with `php artisan queue:autoscale:restart`.
+- **Restart on deploy.** When your code changes, the manager must restart to pick up new code/config. Prefer `php artisan queue:autoscale:restart` in deploy hooks. It lets the running manager drain its spawned workers and exit, then your process supervisor starts it again from the new release.
 
 ## Logs to keep an eye on
 

--- a/docs/deployment/forge.md
+++ b/docs/deployment/forge.md
@@ -35,17 +35,21 @@ You can keep Forge queue workers for queues you list in `queue-autoscale.exclude
 
 ## 3. Deploys
 
-Forge's default zero-downtime deploy script already restarts Daemons via `sudo -S supervisorctl restart`, which sends SIGTERM. The autoscaler catches it, gracefully stops spawned workers, and Forge relaunches the Daemon with new code. No extra steps needed.
-
-If you want to restart manually:
+Add this after the new release is active and migrations/config-cache steps are done:
 
 ```bash
-# Forge → Daemons → Restart button
-# or via SSH:
-sudo supervisorctl restart daemon-<daemon-id>
-# or inside a deploy hook without sudo:
 php artisan queue:autoscale:restart
 ```
+
+The command works like Laravel's `queue:restart`: it writes a cache signal, the running autoscale manager notices it on the next evaluation tick, gracefully stops spawned workers, and exits. Forge's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release.
+
+For a manual graceful restart, run:
+
+```bash
+php artisan queue:autoscale:restart
+```
+
+If the manager is wedged and does not exit, use Forge's **Daemons → Restart** button or `sudo supervisorctl restart daemon-<daemon-id>` as an operational fallback.
 
 ## 4. Verify
 
@@ -61,4 +65,4 @@ You should see `Autoscale manager started` shortly after deploy, then periodic w
 
 - **`.env` changes don't propagate** without a Daemon restart. Forge does this automatically after "Update Secrets" in the UI.
 - **PHP version mismatch.** Forge servers usually run multiple PHP versions. Make sure the Daemon command uses the same `php` binary your web layer uses (`php8.3` or similar if you pin a specific version).
-- **Long-running manager holds old code until restart.** A fresh deploy that changes scaling thresholds won't take effect until the Daemon restarts — which happens automatically on zero-downtime deploy, but not if you skipped that step.
+- **Long-running manager holds old code until restart.** A fresh deploy that changes scaling thresholds won't take effect until the Daemon restarts. Keep `php artisan queue:autoscale:restart` in the deploy script.

--- a/docs/deployment/ploi.md
+++ b/docs/deployment/ploi.md
@@ -34,15 +34,15 @@ See [Queue Topology → Excluded Queues](../basic-usage/queue-topology.md#exclud
 
 ## 3. Deploys
 
-Ploi's deploy script restarts daemons automatically when the deploy hook runs `sudo -S supervisorctl restart`. If your custom deploy script doesn't do this, add:
+Add this near the end of your deploy script, after the new release is active and migrations/config-cache steps are done:
 
 ```bash
-sudo -S supervisorctl restart daemon-<id>
-# or, if your deploy hook only has Artisan access:
 php artisan queue:autoscale:restart
 ```
 
-Find the daemon ID in the Ploi UI or via `supervisorctl status`.
+The command writes a cache signal. The running autoscale manager sees it on the next evaluation tick, gracefully stops spawned workers, and exits. Ploi's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release.
+
+For manual operations, you can still use Ploi's **Daemons → Restart** button or restart the daemon directly with Supervisor. Find the daemon ID in the Ploi UI or via `supervisorctl status`.
 
 ## 4. Verify
 

--- a/docs/deployment/self-hosted-vps.md
+++ b/docs/deployment/self-hosted-vps.md
@@ -46,11 +46,13 @@ sudo systemctl start queue-autoscale
 sudo systemctl status queue-autoscale
 ```
 
-On deploy, restart the daemon so it picks up new code:
+On deploy, signal the manager so it drains workers and exits. systemd will start it again from the current release:
 
 ```bash
-sudo systemctl restart queue-autoscale
+php artisan queue:autoscale:restart
 ```
+
+If the manager is wedged and does not exit, use `sudo systemctl restart queue-autoscale` as an operational fallback.
 
 ## Option B — Supervisor
 
@@ -84,15 +86,11 @@ Your deploy script should trigger exactly one restart path:
 
 ```bash
 php artisan queue:autoscale:restart
-# or
-sudo systemctl restart queue-autoscale
-# or
-sudo supervisorctl restart queue-autoscale
 ```
 
 `php artisan queue:autoscale:restart` works like Laravel's `queue:restart`: it writes a cache signal, the running manager notices it on the next evaluation tick, gracefully terminates all spawned `queue:work` processes, and exits. Your process supervisor then starts a fresh manager with the new code/config.
 
-Direct `systemctl` / `supervisorctl` restarts are also fine; they send SIGTERM immediately, and the manager performs the same graceful shutdown path.
+Direct `systemctl` / `supervisorctl` restarts are still fine as manual fallbacks; they send SIGTERM immediately, and the manager performs the same graceful shutdown path.
 
 **Do not also run `php artisan queue:restart`** — that's for separately-supervised `queue:work` daemons. Our spawned workers are killed directly when the manager shuts down.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,6 +230,14 @@ sudo supervisorctl update
 sudo supervisorctl start queue-autoscale:*
 ```
 
+On deploy, prefer the Artisan restart signal instead of restarting Supervisor directly:
+
+```bash
+php artisan queue:autoscale:restart
+```
+
+The manager drains its spawned workers, exits, and Supervisor starts it again from the new release.
+
 ## Verification
 
 ### See what the autoscaler sees
@@ -281,6 +289,8 @@ QUEUE_AUTOSCALE_COOLDOWN=60
 
 # Manager settings
 QUEUE_AUTOSCALE_EVALUATION_INTERVAL=30
+QUEUE_AUTOSCALE_LOG_CHANNEL=stack
+QUEUE_AUTOSCALE_RESTART_SCOPE=my-app-production
 ```
 
 ## Next Steps

--- a/src/Commands/RestartAutoscaleCommand.php
+++ b/src/Commands/RestartAutoscaleCommand.php
@@ -11,14 +11,14 @@ class RestartAutoscaleCommand extends Command
 {
     public $signature = 'queue:autoscale:restart';
 
-    public $description = 'Signal the queue autoscale manager to gracefully restart';
+    public $description = 'Signal queue autoscale managers to gracefully restart';
 
     public function handle(RestartSignal $restartSignal): int
     {
         $restartSignal->issue();
 
         $this->info('Broadcasting queue autoscale restart signal.');
-        $this->line('The supervised manager will exit after the current evaluation tick and restart with fresh code/config.');
+        $this->line('Supervised managers will exit after the current evaluation tick and restart with fresh code/config.');
 
         return self::SUCCESS;
     }

--- a/src/Configuration/AutoscaleConfiguration.php
+++ b/src/Configuration/AutoscaleConfiguration.php
@@ -67,6 +67,20 @@ final readonly class AutoscaleConfiguration
         return Str::slug($appName, '-').'-'.$appEnv.'-'.$hash;
     }
 
+    public static function restartScopeId(): string
+    {
+        $configured = config('queue-autoscale.manager.restart_scope');
+
+        if (is_string($configured) && trim($configured) !== '') {
+            return Str::slug(trim($configured), '-');
+        }
+
+        $appName = self::stringConfig('app.name', 'laravel');
+        $appEnv = self::stringConfig('app.env', 'production');
+
+        return Str::slug($appName, '-').'-'.$appEnv;
+    }
+
     public static function pickupTimeStore(): string
     {
         $configured = config('queue-autoscale.pickup_time.store', 'auto');

--- a/src/Support/RestartSignal.php
+++ b/src/Support/RestartSignal.php
@@ -14,20 +14,34 @@ final class RestartSignal
         $timestamp = $this->currentTimestamp();
 
         Cache::forever($this->cacheKey(), $timestamp);
+        Cache::forever($this->managerCacheKey(), $timestamp);
 
         return $timestamp;
     }
 
     public function requestedAfter(int $timestamp): bool
     {
-        $restartAt = Cache::get($this->cacheKey());
+        $restartAt = max(
+            $this->numericTimestamp(Cache::get($this->cacheKey())),
+            $this->numericTimestamp(Cache::get($this->managerCacheKey())),
+        );
 
-        return is_numeric($restartAt) && (int) $restartAt > $timestamp;
+        return $restartAt > $timestamp;
     }
 
     public function cacheKey(): string
     {
+        return 'queue-autoscale:restart:'.AutoscaleConfiguration::restartScopeId();
+    }
+
+    public function managerCacheKey(): string
+    {
         return 'queue-autoscale:restart:'.AutoscaleConfiguration::applicationScopeId().':'.AutoscaleConfiguration::managerId();
+    }
+
+    private function numericTimestamp(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
     }
 
     private function currentTimestamp(): int

--- a/tests/Feature/RestartAutoscaleCommandTest.php
+++ b/tests/Feature/RestartAutoscaleCommandTest.php
@@ -2,18 +2,64 @@
 
 declare(strict_types=1);
 
+use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStopped;
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
 use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerPool;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerProcess;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Symfony\Component\Process\Process;
 
 it('writes a restart signal for the autoscale manager', function () {
     $signal = app(RestartSignal::class);
 
     Cache::forget($signal->cacheKey());
+    Cache::forget($signal->managerCacheKey());
 
     $this->artisan('queue:autoscale:restart')
         ->expectsOutput('Broadcasting queue autoscale restart signal.')
         ->assertSuccessful();
 
     expect(Cache::get($signal->cacheKey()))
+        ->toBeInt()
+        ->and(Cache::get($signal->managerCacheKey()))
         ->toBeInt();
+});
+
+it('stops the autoscale manager and drains workers when restart is requested', function () {
+    Event::fake([AutoscaleManagerStopped::class]);
+
+    $signal = app(RestartSignal::class);
+    Cache::forever($signal->cacheKey(), PHP_INT_MAX);
+
+    $manager = app(AutoscaleManager::class);
+
+    $poolProperty = new ReflectionProperty($manager, 'pool');
+    /** @var WorkerPool $pool */
+    $pool = $poolProperty->getValue($manager);
+
+    $process = Mockery::mock(Process::class);
+    $process->shouldReceive('getPid')->andReturn(null);
+    $process->shouldReceive('isRunning')->andReturn(true);
+
+    $pool->add(new WorkerProcess(
+        process: $process,
+        connection: 'redis',
+        queue: 'default',
+        spawnedAt: now(),
+    ));
+
+    try {
+        $result = $manager->run();
+    } finally {
+        Cache::forget($signal->cacheKey());
+    }
+
+    expect($result)->toBe(0);
+
+    Event::assertDispatched(AutoscaleManagerStopped::class, function (AutoscaleManagerStopped $event): bool {
+        return $event->reason === 'restart_signal'
+            && $event->workerCount === 1;
+    });
 });

--- a/tests/Unit/Support/RestartSignalTest.php
+++ b/tests/Unit/Support/RestartSignalTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
 use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
 use Illuminate\Support\Facades\Cache;
 
@@ -10,22 +9,23 @@ beforeEach(function () {
     Cache::flush();
 });
 
-it('scopes the restart key by app scope id and manager id', function () {
+it('uses a deployment-stable restart key by default', function () {
     config()->set('app.name', 'Orderscale');
     config()->set('app.env', 'production');
-    config()->set('queue.default', 'redis');
-    config()->set('queue.connections.redis', [
-        'driver' => 'redis',
-        'connection' => 'default',
-        'queue' => 'default',
-    ]);
     config()->set('queue-autoscale.manager_id', 'node-a');
 
     $signal = app(RestartSignal::class);
 
-    expect($signal->cacheKey())->toContain('queue-autoscale:restart:')
-        ->and($signal->cacheKey())->toContain(AutoscaleConfiguration::applicationScopeId())
-        ->and($signal->cacheKey())->toContain('node-a');
+    expect($signal->cacheKey())->toBe('queue-autoscale:restart:orderscale-production')
+        ->and($signal->cacheKey())->not->toContain('node-a');
+});
+
+it('allows a custom restart scope', function () {
+    config()->set('queue-autoscale.manager.restart_scope', 'Acme Horizon Workers');
+
+    $signal = app(RestartSignal::class);
+
+    expect($signal->cacheKey())->toBe('queue-autoscale:restart:acme-horizon-workers');
 });
 
 it('detects a restart request issued after startup', function () {
@@ -34,6 +34,16 @@ it('detects a restart request issued after startup', function () {
 
     usleep(2000);
     $signal->issue();
+
+    expect($signal->requestedAfter($startedAt))->toBeTrue();
+});
+
+it('detects legacy manager-scoped restart requests', function () {
+    $signal = app(RestartSignal::class);
+    $startedAt = (int) round(microtime(true) * 1000);
+
+    usleep(2000);
+    Cache::forever($signal->managerCacheKey(), (int) round(microtime(true) * 1000));
 
     expect($signal->requestedAfter($startedAt))->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- make queue:autoscale:restart use a deployment-stable restart signal while preserving the legacy manager-scoped signal
- add tests for restart signaling and manager shutdown/drain behavior
- update deployment documentation to prefer the Artisan restart command over direct supervisor/systemd restarts

## Verification
- php -l on changed PHP files
- git diff --check

Note: Pest was not run because this clone has no vendor/ directory.