### PR TITLE
Stabilize autoscaling worker targets

### DIFF
--- a/src/Scaling/Strategies/BacklogOnlyStrategy.php
+++ b/src/Scaling/Strategies/BacklogOnlyStrategy.php
@@ -118,13 +118,6 @@ final class BacklogOnlyStrategy implements ScalingStrategyContract
             }
         }
 
-        // Estimate from current throughput if available
-        $processingRate = $metrics->throughputPerMinute / 60.0;
-        if ($metrics->activeWorkers > 0 && $processingRate > 0) {
-            return $metrics->activeWorkers / $processingRate;
-        }
-
-        // Fallback: assume 1 second per job
-        return 1.0;
+        return AutoscaleConfiguration::fallbackJobTimeSeconds();
     }
 }

--- a/src/Scaling/Strategies/ConservativeStrategy.php
+++ b/src/Scaling/Strategies/ConservativeStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueAutoscale\Scaling\Strategies;
 
+use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
 use Cbox\LaravelQueueAutoscale\Configuration\QueueConfiguration;
 use Cbox\LaravelQueueAutoscale\Contracts\ScalingStrategyContract;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\BacklogDrainCalculator;
@@ -56,7 +57,7 @@ final class ConservativeStrategy implements ScalingStrategyContract
         $oldestJobAge = $metrics->oldestJobAge;
 
         // Determine average job time
-        $avgJobTime = $this->determineJobTime($metrics, $processingRate, $metrics->activeWorkers);
+        $avgJobTime = $this->determineJobTime($metrics);
 
         // 1. Rate-based calculation
         $steadyStateWorkers = $this->littles->calculate($processingRate, $avgJobTime);
@@ -145,23 +146,14 @@ final class ConservativeStrategy implements ScalingStrategyContract
     /**
      * Determine average job time from metrics
      */
-    private function determineJobTime(
-        QueueMetricsData $metrics,
-        float $processingRate,
-        int $activeWorkers
-    ): float {
+    private function determineJobTime(QueueMetricsData $metrics): float
+    {
         if ($metrics->avgDuration > 0) {
             if ($metrics->avgDuration >= 0.01) {
                 return $metrics->avgDuration;
             }
         }
 
-        // Estimate from throughput and active workers
-        if ($activeWorkers > 0 && $processingRate > 0) {
-            return $activeWorkers / $processingRate;
-        }
-
-        // Fallback: assume 1 second per job
-        return 1.0;
+        return AutoscaleConfiguration::fallbackJobTimeSeconds();
     }
 }

--- a/src/Scaling/Strategies/HybridStrategy.php
+++ b/src/Scaling/Strategies/HybridStrategy.php
@@ -63,7 +63,7 @@ final class HybridStrategy implements ScalingStrategyContract
         $this->arrivalRateSource = '';
 
         // Determine average job time
-        [$avgJobTime, $jobTimeSource] = $this->determineJobTime($metrics, $processingRate, $activeWorkers);
+        [$avgJobTime, $jobTimeSource] = $this->determineJobTime($metrics);
 
         // Lazily configure the forecaster from queue config if not already set
         if (! $this->arrivalEstimator->hasForecaster()) {
@@ -97,7 +97,6 @@ final class HybridStrategy implements ScalingStrategyContract
         if ($arrivalRate === 0.0) {
             $arrivalRate = $this->estimateFallbackArrivalRate(
                 $backlogSize,
-                $activeWorkers,
                 $oldestJobAge,
                 $avgJobTime,
                 $config->sla->targetSeconds
@@ -356,8 +355,7 @@ final class HybridStrategy implements ScalingStrategyContract
      *
      * Priority order:
      * 1. Average duration from metrics (when available, always in seconds)
-     * 2. Estimation from throughput and worker count
-     * 3. Configurable fallback (default: 2.0 seconds)
+     * 2. Configurable fallback (default: 2.0 seconds)
      *
      * Note: The metrics package provides avgDuration in milliseconds, but
      * AutoscaleManager::mapMetricsFields() converts to seconds before creating
@@ -365,11 +363,8 @@ final class HybridStrategy implements ScalingStrategyContract
      *
      * @return array{float, string} [avgJobTime, source]
      */
-    private function determineJobTime(
-        QueueMetricsData $metrics,
-        float $processingRate,
-        int $activeWorkers
-    ): array {
+    private function determineJobTime(QueueMetricsData $metrics): array
+    {
         // Priority 1: Use average duration from metrics (already in seconds)
         if ($metrics->avgDuration > 0) {
             $avgDurationSeconds = $metrics->avgDuration;
@@ -381,17 +376,7 @@ final class HybridStrategy implements ScalingStrategyContract
             }
         }
 
-        // Priority 2: Estimate from throughput and active workers
-        if ($activeWorkers > 0 && $processingRate > 0) {
-            $estimated = $activeWorkers / $processingRate;
-
-            // Sanity check: cap at reasonable maximum (10 minutes)
-            $estimated = min($estimated, 600.0);
-
-            return [$estimated, sprintf('estimated: %d workers / %.2f rate = %.2fs', $activeWorkers, $processingRate, $estimated)];
-        }
-
-        // Priority 3: Configurable fallback
+        // Priority 2: Configurable fallback
         $fallback = AutoscaleConfiguration::fallbackJobTimeSeconds();
 
         return [$fallback, sprintf('fallback: %.1fs (configurable)', $fallback)];
@@ -404,7 +389,6 @@ final class HybridStrategy implements ScalingStrategyContract
      * Does NOT estimate from worker capacity - having workers doesn't mean jobs are arriving.
      *
      * @param  int  $backlogSize  Number of pending jobs
-     * @param  int  $activeWorkers  Current active workers (unused - kept for signature)
      * @param  int  $oldestJobAge  Age of oldest job in seconds
      * @param  float  $avgJobTime  Average processing time per job
      * @param  int  $slaTarget  Max pickup time SLA in seconds
@@ -412,7 +396,6 @@ final class HybridStrategy implements ScalingStrategyContract
      */
     private function estimateFallbackArrivalRate(
         int $backlogSize,
-        int $activeWorkers,
         int $oldestJobAge,
         float $avgJobTime,
         int $slaTarget,

--- a/src/Scaling/Strategies/SimpleRateStrategy.php
+++ b/src/Scaling/Strategies/SimpleRateStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueAutoscale\Scaling\Strategies;
 
+use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
 use Cbox\LaravelQueueAutoscale\Configuration\QueueConfiguration;
 use Cbox\LaravelQueueAutoscale\Contracts\ScalingStrategyContract;
 use Cbox\LaravelQueueAutoscale\Scaling\Calculators\LittlesLawCalculator;
@@ -40,7 +41,7 @@ final class SimpleRateStrategy implements ScalingStrategyContract
         $processingRate = $metrics->throughputPerMinute / 60.0;
 
         // Determine average job time
-        $avgJobTime = $this->determineJobTime($metrics, $processingRate, $metrics->activeWorkers);
+        $avgJobTime = $this->determineJobTime($metrics);
 
         // Calculate steady-state workers using Little's Law (L = λW)
         $targetWorkers = $this->littles->calculate($processingRate, $avgJobTime);
@@ -84,23 +85,14 @@ final class SimpleRateStrategy implements ScalingStrategyContract
     /**
      * Determine average job time from metrics
      */
-    private function determineJobTime(
-        QueueMetricsData $metrics,
-        float $processingRate,
-        int $activeWorkers
-    ): float {
+    private function determineJobTime(QueueMetricsData $metrics): float
+    {
         if ($metrics->avgDuration > 0) {
             if ($metrics->avgDuration >= 0.01) {
                 return $metrics->avgDuration;
             }
         }
 
-        // Estimate from throughput and active workers
-        if ($activeWorkers > 0 && $processingRate > 0) {
-            return $activeWorkers / $processingRate;
-        }
-
-        // Fallback: assume 1 second per job
-        return 1.0;
+        return AutoscaleConfiguration::fallbackJobTimeSeconds();
     }
 }

--- a/tests/Unit/HybridStrategyBehaviourTest.php
+++ b/tests/Unit/HybridStrategyBehaviourTest.php
@@ -68,7 +68,7 @@ describe('steady state calculations', function () {
             'oldest_job_age' => 0,
         ]);
 
-        // Avg job time: 4 workers / 2 jobs/sec = 2 sec/job
+        // Fallback avg job time: 2 sec
         // Little's Law: 2 jobs/sec × 2 sec = 4 workers (within max=10)
         $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
 
@@ -76,7 +76,7 @@ describe('steady state calculations', function () {
         expect($workers)->toBeGreaterThanOrEqual(4);
     });
 
-    it('estimates average job time from processing rate and active workers', function () {
+    it('uses fallback average job time instead of deriving it from active workers', function () {
         $metrics = createMetrics([
             'throughput_per_minute' => 120.0, // 2.0 jobs/sec * 60
             'active_workers' => 6,
@@ -84,11 +84,11 @@ describe('steady state calculations', function () {
             'oldest_job_age' => 0,
         ]);
 
-        // Avg job time: 6 workers / 2 jobs/sec = 3 sec/job
-        // Steady state: 2 jobs/sec × 3 sec = 6 workers (within max=10)
+        // Fallback avg job time: 2 sec
+        // Steady state: 2 jobs/sec × 2 sec = 4 workers (within max=10)
         $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
 
-        expect($workers)->toBeGreaterThanOrEqual(6);
+        expect($workers)->toBe(4);
     });
 
     it('uses configurable fallback average job time when no active workers', function () {
@@ -140,7 +140,7 @@ describe('backlog drain calculations', function () {
             'oldest_job_age' => 25, // approaching SLA (30s)
         ]);
 
-        // Avg job time: 2 sec
+        // Fallback avg job time: 2 sec
         // Steady: 2 × 2 = 4 workers
         // Backlog drain will be higher due to imminent breach
         $workers = $this->strategy->calculateTargetWorkers($metrics, $config);
@@ -158,7 +158,7 @@ describe('backlog drain calculations', function () {
             'oldest_job_age' => 28, // very close to SLA breach
         ]);
 
-        // Avg job time: 4 / 2 = 2 sec
+        // Fallback avg job time: 2 sec
         // Steady state: 2 × 2 = 4 workers
         // Backlog drain: will be much higher (approaching breach)
         $workers = $this->strategy->calculateTargetWorkers($metrics, $config);
@@ -339,8 +339,8 @@ describe('fallback arrival rate estimation', function () {
 
         $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
 
-        // Should NOT return 0 workers despite zero throughput
-        // Fallback estimates from active workers' capacity
+        // Should NOT return 0 workers despite zero throughput.
+        // Fallback estimates from backlog demand, not worker capacity.
         expect($workers)->toBeGreaterThan(0);
     });
 
@@ -521,6 +521,22 @@ describe('metrics handling', function () {
         // Workers = rate * avgDuration = 10 * 3 = 30 (within max=50)
         expect($workers)->toBeGreaterThanOrEqual(30)
             ->and($reason)->toContain('3'); // Should reference 3 second job time
+    });
+
+    it('does not preserve inflated worker count when duration metrics are missing', function () {
+        $config = makeQueueConfig(['minWorkers' => 0, 'maxWorkers' => 100]);
+        $metrics = createMetrics([
+            'throughput_per_minute' => 88.0,
+            'active_workers' => 18,
+            'pending' => 1,
+            'oldest_job_age' => 1,
+            'avg_duration' => 0.0,
+            'utilization_rate' => 0.0,
+        ]);
+
+        $workers = $this->strategy->calculateTargetWorkers($metrics, $config);
+
+        expect($workers)->toBe(3);
     });
 });
 

--- a/tests/Unit/Scaling/Strategies/BacklogOnlyStrategyTest.php
+++ b/tests/Unit/Scaling/Strategies/BacklogOnlyStrategyTest.php
@@ -33,6 +33,21 @@ test('returns zero workers for empty backlog', function () {
     expect($workers)->toBe(0);
 });
 
+test('uses fallback job time instead of deriving it from active workers', function () {
+    $metrics = MetricsHelper::createMetrics([
+        'pending' => 30,
+        'throughputPerMinute' => 60.0,
+        'avgDuration' => 0.0,
+        'oldestJobAge' => 0,
+        'activeWorkers' => 20,
+    ]);
+
+    $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
+
+    // Fallback job time: 2s. 30 jobs can be cleared inside the 30s SLA by 2 workers.
+    expect($workers)->toBe(2);
+});
+
 test('scales aggressively for old backlog', function () {
     $metrics = MetricsHelper::createMetrics([
         'pending' => 50,

--- a/tests/Unit/Scaling/Strategies/ConservativeStrategyTest.php
+++ b/tests/Unit/Scaling/Strategies/ConservativeStrategyTest.php
@@ -34,6 +34,21 @@ test('returns zero workers for idle queue', function () {
     expect($workers)->toBe(0);
 });
 
+test('uses fallback job time instead of deriving it from active workers', function () {
+    $metrics = MetricsHelper::createMetrics([
+        'pending' => 0,
+        'throughputPerMinute' => 60.0,
+        'avgDuration' => 0.0,
+        'oldestJobAge' => 0,
+        'activeWorkers' => 20,
+    ]);
+
+    $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
+
+    // Fallback job time: 2s. Little's Law gives 2 workers, then 25% buffer rounds to 3.
+    expect($workers)->toBe(3);
+});
+
 test('scales more aggressively than simple strategy', function () {
     $metrics = MetricsHelper::createMetrics([
         'pending' => 50,

--- a/tests/Unit/Scaling/Strategies/SimpleRateStrategyTest.php
+++ b/tests/Unit/Scaling/Strategies/SimpleRateStrategyTest.php
@@ -39,13 +39,14 @@ test('uses fallback job time when metrics unavailable', function () {
         'throughputPerMinute' => 60.0, // 1 job/sec
         'avgDuration' => 0, // No duration data
         'oldestJobAge' => 5,
+        'activeWorkers' => 20,
     ]);
 
     $workers = $this->strategy->calculateTargetWorkers($metrics, $this->config);
 
-    // With no duration data, falls back to 1 second
-    // Little's Law: L = 1 job/s × 1s = 1 worker
-    expect($workers)->toBe(1);
+    // With no duration data, falls back to the configured 2 second job time.
+    // Little's Law: L = 1 job/s × 2s = 2 workers
+    expect($workers)->toBe(2);
 });
 
 test('provides descriptive reason', function () {


### PR DESCRIPTION
## Summary
- Use measured average job duration when available and the configured fallback job time otherwise.
- Stop deriving job time from the current active worker count, which could preserve inflated targets under low load.
- Renew cluster leader leases with a single atomic Redis script, so an expired leader cannot overwrite a newly elected one.
- Tag cluster recommendations with the publishing leader and ignore stale recommendations after leadership changes.
- Add regression coverage across scaling strategies, leader lease behavior, and recommendation handoff.

## Root Cause
When duration metrics were missing, several strategies estimated job time as active workers divided by throughput. That made the current worker count feed back into the demand calculation, so an already high worker count could be treated as evidence that the same high worker count was required.

Leader renewal also used a non-atomic read-then-write path. If the lease expired between the read and renewal write, the old leader could overwrite a newer leader lease. Published recommendations could also outlive a leader lease, so a manager could apply a recommendation from a previous leader during a transition.

## Validation
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`