### PR TITLE
Harden cluster leader leases

### DIFF
--- a/src/Cluster/ClusterRecommendation.php
+++ b/src/Cluster/ClusterRecommendation.php
@@ -13,6 +13,7 @@ final readonly class ClusterRecommendation
         public string $managerId,
         public int $issuedAt,
         public array $workloads,
+        public ?string $leaderId = null,
     ) {}
 
     public static function queueWorkloadKey(string $connection, string $queue): string
@@ -44,6 +45,7 @@ final readonly class ClusterRecommendation
             'manager_id' => $this->managerId,
             'issued_at' => $this->issuedAt,
             'workloads' => $this->workloads,
+            'leader_id' => $this->leaderId,
         ];
     }
 
@@ -65,11 +67,13 @@ final readonly class ClusterRecommendation
         }
 
         $managerId = $payload['manager_id'] ?? null;
+        $leaderId = $payload['leader_id'] ?? null;
 
         return new self(
             managerId: is_string($managerId) ? $managerId : '',
             issuedAt: is_numeric($payload['issued_at'] ?? null) ? (int) $payload['issued_at'] : 0,
             workloads: $workloads,
+            leaderId: is_string($leaderId) && $leaderId !== '' ? $leaderId : null,
         );
     }
 }

--- a/src/Cluster/ClusterRecommendation.php
+++ b/src/Cluster/ClusterRecommendation.php
@@ -14,6 +14,7 @@ final readonly class ClusterRecommendation
         public int $issuedAt,
         public array $workloads,
         public ?string $leaderId = null,
+        public ?string $leaderToken = null,
     ) {}
 
     public static function queueWorkloadKey(string $connection, string $queue): string
@@ -46,6 +47,7 @@ final readonly class ClusterRecommendation
             'issued_at' => $this->issuedAt,
             'workloads' => $this->workloads,
             'leader_id' => $this->leaderId,
+            'leader_token' => $this->leaderToken,
         ];
     }
 
@@ -68,12 +70,14 @@ final readonly class ClusterRecommendation
 
         $managerId = $payload['manager_id'] ?? null;
         $leaderId = $payload['leader_id'] ?? null;
+        $leaderToken = $payload['leader_token'] ?? null;
 
         return new self(
             managerId: is_string($managerId) ? $managerId : '',
             issuedAt: is_numeric($payload['issued_at'] ?? null) ? (int) $payload['issued_at'] : 0,
             workloads: $workloads,
             leaderId: is_string($leaderId) && $leaderId !== '' ? $leaderId : null,
+            leaderToken: is_string($leaderToken) && $leaderToken !== '' ? $leaderToken : null,
         );
     }
 }

--- a/src/Cluster/ClusterStore.php
+++ b/src/Cluster/ClusterStore.php
@@ -86,12 +86,27 @@ class ClusterStore
         return is_string($managerId) && $managerId !== '' ? $managerId : null;
     }
 
+    public function leaderToken(): ?string
+    {
+        $payload = $this->decode($this->redis()->get($this->leaderKey()));
+
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $token = $payload['leader_token'] ?? null;
+
+        return is_string($token) && $token !== '' ? $token : null;
+    }
+
     public function isLeader(string $managerId): bool
     {
         $redis = $this->redis();
+        $renewedAt = $this->currentTimestamp();
         $payload = [
             'manager_id' => $managerId,
-            'renewed_at' => $this->currentTimestamp(),
+            'renewed_at' => $renewedAt,
+            'leader_token' => $this->newLeaderToken(),
         ];
 
         $script = <<<'LUA'
@@ -105,7 +120,13 @@ end
 local decoded_ok, decoded = pcall(cjson.decode, current)
 
 if decoded_ok and decoded['manager_id'] == ARGV[3] then
-    redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
+    if decoded['leader_token'] == nil or decoded['leader_token'] == '' then
+        redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
+    else
+        decoded['renewed_at'] = tonumber(ARGV[4]) or ARGV[4]
+        redis.call('setex', KEYS[1], ARGV[2], cjson.encode(decoded))
+    end
+
     return 1
 end
 
@@ -116,8 +137,8 @@ LUA;
         $ttl = AutoscaleConfiguration::clusterLeaderLeaseSeconds();
 
         $acquired = $redis instanceof PhpRedisConnection
-            ? $redis->command('eval', [$script, [$leaderKey, $encodedPayload, $ttl, $managerId], 1])
-            : $redis->command('eval', [$script, 1, $leaderKey, $encodedPayload, $ttl, $managerId]);
+            ? $redis->command('eval', [$script, [$leaderKey, $encodedPayload, $ttl, $managerId, $renewedAt], 1])
+            : $redis->command('eval', [$script, 1, $leaderKey, $encodedPayload, $ttl, $managerId, $renewedAt]);
 
         return $acquired === true || $acquired === 1 || $acquired === '1';
     }
@@ -248,6 +269,11 @@ LUA;
     private function currentTimestamp(): int
     {
         return (int) round(microtime(true) * 1000);
+    }
+
+    private function newLeaderToken(): string
+    {
+        return bin2hex(random_bytes(16));
     }
 
     private function managersRegistryKey(): string

--- a/src/Cluster/ClusterStore.php
+++ b/src/Cluster/ClusterStore.php
@@ -89,24 +89,22 @@ class ClusterStore
     public function isLeader(string $managerId): bool
     {
         $redis = $this->redis();
-        $current = $this->leaderId();
         $payload = [
             'manager_id' => $managerId,
             'renewed_at' => $this->currentTimestamp(),
         ];
 
-        if ($current === $managerId) {
-            $redis->setex(
-                $this->leaderKey(),
-                AutoscaleConfiguration::clusterLeaderLeaseSeconds(),
-                $this->encode($payload),
-            );
-
-            return true;
-        }
-
         $script = <<<'LUA'
-if redis.call('exists', KEYS[1]) == 0 then
+local current = redis.call('get', KEYS[1])
+
+if not current then
+    redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
+    return 1
+end
+
+local decoded_ok, decoded = pcall(cjson.decode, current)
+
+if decoded_ok and decoded['manager_id'] == ARGV[3] then
     redis.call('setex', KEYS[1], ARGV[2], ARGV[1])
     return 1
 end
@@ -118,8 +116,8 @@ LUA;
         $ttl = AutoscaleConfiguration::clusterLeaderLeaseSeconds();
 
         $acquired = $redis instanceof PhpRedisConnection
-            ? $redis->command('eval', [$script, [$leaderKey, $encodedPayload, $ttl], 1])
-            : $redis->command('eval', [$script, 1, $leaderKey, $encodedPayload, $ttl]);
+            ? $redis->command('eval', [$script, [$leaderKey, $encodedPayload, $ttl, $managerId], 1])
+            : $redis->command('eval', [$script, 1, $leaderKey, $encodedPayload, $ttl, $managerId]);
 
         return $acquired === true || $acquired === 1 || $acquired === '1';
     }

--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -568,6 +568,7 @@ final class AutoscaleManager
                     managerId: $managerId,
                     issuedAt: $issuedAt,
                     workloads: $assignments[$managerId],
+                    leaderId: AutoscaleConfiguration::managerId(),
                 )
             );
         }
@@ -599,6 +600,15 @@ final class AutoscaleManager
 
     private function applyClusterRecommendation(ClusterRecommendation $recommendation): void
     {
+        if ($recommendation->leaderId !== null && $recommendation->leaderId !== $this->clusterStore->leaderId()) {
+            $this->verbose(
+                "Ignoring stale cluster recommendation from previous leader={$recommendation->leaderId}",
+                'debug',
+            );
+
+            return;
+        }
+
         $groups = GroupConfiguration::allFromConfig();
         $groupedQueueKeys = $this->groupedQueueKeys($groups);
 

--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -561,6 +561,7 @@ final class AutoscaleManager
         );
 
         $issuedAt = $this->currentTimestamp();
+        $leaderToken = $this->clusterStore->leaderToken();
 
         foreach ($managerIds as $managerId) {
             $this->clusterStore->publishRecommendation(
@@ -569,6 +570,7 @@ final class AutoscaleManager
                     issuedAt: $issuedAt,
                     workloads: $assignments[$managerId],
                     leaderId: AutoscaleConfiguration::managerId(),
+                    leaderToken: $leaderToken,
                 )
             );
         }
@@ -603,6 +605,15 @@ final class AutoscaleManager
         if ($recommendation->leaderId !== null && $recommendation->leaderId !== $this->clusterStore->leaderId()) {
             $this->verbose(
                 "Ignoring stale cluster recommendation from previous leader={$recommendation->leaderId}",
+                'debug',
+            );
+
+            return;
+        }
+
+        if ($recommendation->leaderToken !== null && $recommendation->leaderToken !== $this->clusterStore->leaderToken()) {
+            $this->verbose(
+                'Ignoring stale cluster recommendation from previous leader lease',
                 'debug',
             );
 

--- a/tests/Feature/ClusterRecommendationApplyTest.php
+++ b/tests/Feature/ClusterRecommendationApplyTest.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Cbox\LaravelQueueAutoscale\Cluster\ClusterRecommendation;
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterStore;
 use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
 use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
 use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
 use Illuminate\Support\Facades\Event;
+use Mockery\MockInterface;
 
 it('applies cluster recommendation for discovered queues not in explicit config', function () {
     config()->set('queue-autoscale.queues', []);
@@ -75,6 +77,36 @@ it('skips excluded queues in cluster recommendation', function () {
         workloads: [
             'queue:redis:ignored' => 2,
         ],
+    );
+
+    $manager = app(AutoscaleManager::class);
+
+    $method = new ReflectionMethod($manager, 'applyClusterRecommendation');
+    $method->invoke($manager, $recommendation);
+
+    Event::assertNotDispatched(WorkersScaled::class);
+});
+
+it('ignores stale recommendations from a previous leader', function () {
+    config()->set('queue-autoscale.queues', []);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $this->mock(ClusterStore::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('leaderId')
+            ->once()
+            ->andReturn('current-leader');
+    });
+
+    $recommendation = new ClusterRecommendation(
+        managerId: 'test-mgr',
+        issuedAt: now()->timestamp,
+        workloads: [
+            'queue:redis:default' => 2,
+        ],
+        leaderId: 'previous-leader',
     );
 
     $manager = app(AutoscaleManager::class);

--- a/tests/Feature/ClusterRecommendationApplyTest.php
+++ b/tests/Feature/ClusterRecommendationApplyTest.php
@@ -116,3 +116,37 @@ it('ignores stale recommendations from a previous leader', function () {
 
     Event::assertNotDispatched(WorkersScaled::class);
 });
+
+it('ignores stale recommendations from a previous lease held by the same leader id', function () {
+    config()->set('queue-autoscale.queues', []);
+    config()->set('queue-autoscale.groups', []);
+    config()->set('queue-autoscale.excluded', []);
+
+    Event::fake([WorkersScaled::class]);
+
+    $this->mock(ClusterStore::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('leaderId')
+            ->once()
+            ->andReturn('leader-a');
+        $mock->shouldReceive('leaderToken')
+            ->once()
+            ->andReturn('current-lease-token');
+    });
+
+    $recommendation = new ClusterRecommendation(
+        managerId: 'test-mgr',
+        issuedAt: now()->timestamp,
+        workloads: [
+            'queue:redis:default' => 2,
+        ],
+        leaderId: 'leader-a',
+        leaderToken: 'previous-lease-token',
+    );
+
+    $manager = app(AutoscaleManager::class);
+
+    $method = new ReflectionMethod($manager, 'applyClusterRecommendation');
+    $method->invoke($manager, $recommendation);
+
+    Event::assertNotDispatched(WorkersScaled::class);
+});

--- a/tests/Unit/Cluster/ClusterDataTransferObjectsTest.php
+++ b/tests/Unit/Cluster/ClusterDataTransferObjectsTest.php
@@ -92,6 +92,7 @@ it('resolves recommendation targets for queues and groups', function () {
             ClusterRecommendation::groupWorkloadKey('redis', 'mailers') => 1,
         ],
         leaderId: 'leader-a',
+        leaderToken: 'lease-token-a',
     );
 
     $decoded = ClusterRecommendation::fromArray($recommendation->toArray());
@@ -99,7 +100,8 @@ it('resolves recommendation targets for queues and groups', function () {
     expect($decoded->targetForQueue('redis', 'default'))->toBe(2)
         ->and($decoded->targetForGroup('redis', 'mailers'))->toBe(1)
         ->and($decoded->targetForQueue('redis', 'missing'))->toBe(0)
-        ->and($decoded->leaderId)->toBe('leader-a');
+        ->and($decoded->leaderId)->toBe('leader-a')
+        ->and($decoded->leaderToken)->toBe('lease-token-a');
 });
 
 it('keeps legacy recommendations without a leader id readable', function () {
@@ -112,5 +114,6 @@ it('keeps legacy recommendations without a leader id readable', function () {
     ]);
 
     expect($decoded->targetForQueue('redis', 'default'))->toBe(2)
-        ->and($decoded->leaderId)->toBeNull();
+        ->and($decoded->leaderId)->toBeNull()
+        ->and($decoded->leaderToken)->toBeNull();
 });

--- a/tests/Unit/Cluster/ClusterDataTransferObjectsTest.php
+++ b/tests/Unit/Cluster/ClusterDataTransferObjectsTest.php
@@ -91,11 +91,26 @@ it('resolves recommendation targets for queues and groups', function () {
             ClusterRecommendation::queueWorkloadKey('redis', 'default') => 2,
             ClusterRecommendation::groupWorkloadKey('redis', 'mailers') => 1,
         ],
+        leaderId: 'leader-a',
     );
 
     $decoded = ClusterRecommendation::fromArray($recommendation->toArray());
 
     expect($decoded->targetForQueue('redis', 'default'))->toBe(2)
         ->and($decoded->targetForGroup('redis', 'mailers'))->toBe(1)
-        ->and($decoded->targetForQueue('redis', 'missing'))->toBe(0);
+        ->and($decoded->targetForQueue('redis', 'missing'))->toBe(0)
+        ->and($decoded->leaderId)->toBe('leader-a');
+});
+
+it('keeps legacy recommendations without a leader id readable', function () {
+    $decoded = ClusterRecommendation::fromArray([
+        'manager_id' => 'manager-a',
+        'issued_at' => 1234,
+        'workloads' => [
+            ClusterRecommendation::queueWorkloadKey('redis', 'default') => 2,
+        ],
+    ]);
+
+    expect($decoded->targetForQueue('redis', 'default'))->toBe(2)
+        ->and($decoded->leaderId)->toBeNull();
 });

--- a/tests/Unit/Cluster/ClusterStoreTest.php
+++ b/tests/Unit/Cluster/ClusterStoreTest.php
@@ -7,38 +7,61 @@ use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Facades\Redis;
 use Mockery\MockInterface;
 
-it('acquires a new leader lease through eval so it works with phpredis', function () {
+beforeEach(function (): void {
     config()->set('app.name', 'Queue Autoscale Test');
     config()->set('app.env', 'testing');
     config()->set('queue.default', 'redis');
     config()->set('queue.connections.redis', ['driver' => 'redis', 'connection' => 'default']);
     config()->set('queue-autoscale.cluster.leader_lease_seconds', 15);
+});
 
+it('acquires or renews the leader lease atomically through eval for phpredis', function () {
     $connection = Mockery::mock(PhpRedisConnection::class, function (MockInterface $mock): void {
-        $mock->shouldReceive('get')->once()->andReturn(null);
+        $mock->shouldNotReceive('get');
+        $mock->shouldNotReceive('setex');
         $mock->shouldReceive('command')
             ->once()
             ->withArgs(function (string $method, array $parameters): bool {
                 expect($method)->toBe('eval');
                 expect($parameters)->toHaveCount(3);
                 [$script, $arguments, $numberOfKeys] = $parameters;
+                expect($script)->toContain("redis.call('get'");
+                expect($script)->toContain('pcall(cjson.decode');
+                expect($script)->toContain("decoded['manager_id'] == ARGV[3]");
                 expect($script)->toContain("redis.call('setex'");
-                expect($arguments)->toHaveCount(3);
-                [$key, $payload, $ttl] = $arguments;
+                expect($arguments)->toHaveCount(4);
+                [$key, $payload, $ttl, $managerId] = $arguments;
                 expect($numberOfKeys)->toBe(1);
                 expect($key)->toContain('queue-autoscale:cluster:');
                 expect(json_decode($payload, true, 512, JSON_THROW_ON_ERROR))->toMatchArray([
                     'manager_id' => 'manager-a',
                 ]);
                 expect($ttl)->toBe(15);
+                expect($managerId)->toBe('manager-a');
 
                 return true;
             })
             ->andReturn(1);
     });
 
-    Redis::shouldReceive('connection')->twice()->andReturn($connection);
+    Redis::shouldReceive('connection')->once()->andReturn($connection);
     $store = new ClusterStore;
 
     expect($store->isLeader('manager-a'))->toBeTrue();
+});
+
+it('does not treat the manager as leader when the atomic lease script rejects it', function () {
+    $connection = Mockery::mock(PhpRedisConnection::class, function (MockInterface $mock): void {
+        $mock->shouldNotReceive('get');
+        $mock->shouldNotReceive('setex');
+        $mock->shouldReceive('command')
+            ->once()
+            ->with('eval', Mockery::type('array'))
+            ->andReturn(0);
+    });
+
+    Redis::shouldReceive('connection')->once()->andReturn($connection);
+    $store = new ClusterStore;
+
+    expect($store->isLeader('manager-a'))->toBeFalse();
 });

--- a/tests/Unit/Cluster/ClusterStoreTest.php
+++ b/tests/Unit/Cluster/ClusterStoreTest.php
@@ -28,16 +28,22 @@ it('acquires or renews the leader lease atomically through eval for phpredis', f
                 expect($script)->toContain("redis.call('get'");
                 expect($script)->toContain('pcall(cjson.decode');
                 expect($script)->toContain("decoded['manager_id'] == ARGV[3]");
+                expect($script)->toContain("decoded['leader_token']");
                 expect($script)->toContain("redis.call('setex'");
-                expect($arguments)->toHaveCount(4);
-                [$key, $payload, $ttl, $managerId] = $arguments;
+                expect($arguments)->toHaveCount(5);
+                [$key, $payload, $ttl, $managerId, $renewedAt] = $arguments;
                 expect($numberOfKeys)->toBe(1);
                 expect($key)->toContain('queue-autoscale:cluster:');
-                expect(json_decode($payload, true, 512, JSON_THROW_ON_ERROR))->toMatchArray([
+                $decodedPayload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+                expect($decodedPayload)->toMatchArray([
                     'manager_id' => 'manager-a',
                 ]);
+                expect($decodedPayload['leader_token'] ?? null)->toBeString();
+                expect($decodedPayload['leader_token'])->not->toBe('');
+                expect($decodedPayload['renewed_at'] ?? null)->toBeInt();
                 expect($ttl)->toBe(15);
                 expect($managerId)->toBe('manager-a');
+                expect($renewedAt)->toBeInt();
 
                 return true;
             })
@@ -64,4 +70,22 @@ it('does not treat the manager as leader when the atomic lease script rejects it
     $store = new ClusterStore;
 
     expect($store->isLeader('manager-a'))->toBeFalse();
+});
+
+it('reads the current leader fencing token from the lease payload', function () {
+    $connection = Mockery::mock(PhpRedisConnection::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('get')
+            ->once()
+            ->with(Mockery::type('string'))
+            ->andReturn(json_encode([
+                'manager_id' => 'manager-a',
+                'renewed_at' => 1234,
+                'leader_token' => 'lease-token-a',
+            ], JSON_THROW_ON_ERROR));
+    });
+
+    Redis::shouldReceive('connection')->once()->andReturn($connection);
+    $store = new ClusterStore;
+
+    expect($store->leaderToken())->toBe('lease-token-a');
 });


### PR DESCRIPTION
## Summary
- Renew and acquire the cluster leader lease with a single atomic Redis Lua script.
- Prevent an expired leader from overwriting a newly elected leader during renewal races.
- Add a leader lease fencing token to cluster recommendations.
- Ignore stale recommendations when the leader id matches but the lease token is from a previous leadership epoch.
- Preserve compatibility with legacy recommendation payloads that do not include leader metadata.

## Root Cause
Leader renewal previously relied on a non-atomic read-then-write path, so an expired leader could race with a newly elected leader. Recommendations were also fenced only by leader id, which is not enough when the same manager id restarts or reacquires leadership while older recommendation payloads are still within TTL.

## Validation
- `vendor/bin/pest tests/Unit/Cluster/ClusterStoreTest.php tests/Unit/Cluster/ClusterDataTransferObjectsTest.php tests/Feature/ClusterRecommendationApplyTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`