### PR TITLE
Make worker scale-down non-blocking

### DIFF
--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -232,6 +232,7 @@ final class AutoscaleManager
 
             try {
                 $this->processWorkerOutput();
+                $this->enforceTerminationDeadlines();
                 $this->cleanupDeadWorkers();
 
                 if (AutoscaleConfiguration::clusterEnabled()) {
@@ -1898,10 +1899,10 @@ final class AutoscaleManager
 
         $this->verbose("  ⬇️  Scaling group DOWN: terminating {$toRemove} worker(s) in '{$group->name}'", 'info');
 
-        $workers = $this->pool->removeFromGroup($group->connection, $group->name, $toRemove);
+        $workers = $this->pool->getTerminatableFromGroup($group->connection, $group->name, $toRemove);
 
         foreach ($workers as $worker) {
-            $this->terminator->terminate($worker);
+            $this->terminator->requestTermination($worker);
         }
 
         Log::channel(AutoscaleConfiguration::logChannel())->info(
@@ -1999,10 +2000,10 @@ final class AutoscaleManager
             $toRemove = $current - $target;
             $this->verbose("  ⬇️  Supervisor trim: terminating {$toRemove} excess worker(s)", 'info');
 
-            $workers = $this->pool->remove($connection, $queue, $toRemove);
+            $workers = $this->pool->getTerminatable($connection, $queue, $toRemove);
 
             foreach ($workers as $worker) {
-                $this->terminator->terminate($worker);
+                $this->terminator->requestTermination($worker);
             }
 
             Log::channel(AutoscaleConfiguration::logChannel())->info(
@@ -2138,15 +2139,15 @@ final class AutoscaleManager
             $decision->reason
         );
 
-        $workers = $this->pool->remove(
+        $workers = $this->pool->getTerminatable(
             $decision->connection,
             $decision->queue,
             $toRemove
         );
 
         foreach ($workers as $worker) {
-            $this->verbose("     ✓ Terminating worker: PID {$worker->pid()}", 'info');
-            $this->terminator->terminate($worker);
+            $this->verbose("     ✓ Requesting worker termination: PID {$worker->pid()}", 'info');
+            $this->terminator->requestTermination($worker);
         }
 
         Log::channel(AutoscaleConfiguration::logChannel())->info(
@@ -2191,6 +2192,13 @@ final class AutoscaleManager
         }
     }
 
+    private function enforceTerminationDeadlines(): void
+    {
+        foreach ($this->pool->getTerminatingWorkers() as $worker) {
+            $this->terminator->forceKillIfExpired($worker);
+        }
+    }
+
     private function processWorkerOutput(): void
     {
         if ($this->renderer === null) {
@@ -2228,7 +2236,7 @@ final class AutoscaleManager
                 pid: $worker->pid(),
                 connection: $worker->connection,
                 queue: $worker->queue,
-                status: $worker->isRunning() ? 'running' : 'dead',
+                status: $worker->isTerminating() ? 'terminating' : ($worker->isRunning() ? 'running' : 'dead'),
                 uptimeSeconds: $worker->uptimeSeconds(),
             );
             $id++;

--- a/src/Workers/WorkerPool.php
+++ b/src/Workers/WorkerPool.php
@@ -102,21 +102,21 @@ final class WorkerPool
     public function count(string $connection, string $queue): int
     {
         return $this->workers->filter(
-            fn (WorkerProcess $w) => $w->matches($connection, $queue) && $w->isRunning()
+            fn (WorkerProcess $w) => $w->matches($connection, $queue) && $w->isRunning() && ! $w->isTerminating()
         )->count();
     }
 
     public function countGroup(string $connection, string $group): int
     {
         return $this->workers->filter(
-            fn (WorkerProcess $w) => $w->matchesGroup($connection, $group) && $w->isRunning()
+            fn (WorkerProcess $w) => $w->matchesGroup($connection, $group) && $w->isRunning() && ! $w->isTerminating()
         )->count();
     }
 
     public function totalCount(): int
     {
         return $this->workers->filter(
-            fn (WorkerProcess $w) => $w->isRunning()
+            fn (WorkerProcess $w) => $w->isRunning() && ! $w->isTerminating()
         )->count();
     }
 
@@ -128,7 +128,7 @@ final class WorkerPool
         $counts = [];
 
         foreach ($this->workers as $worker) {
-            if (! $worker->isRunning() || $worker->isGroupWorker()) {
+            if (! $worker->isRunning() || $worker->isTerminating() || $worker->isGroupWorker()) {
                 continue;
             }
 
@@ -149,7 +149,7 @@ final class WorkerPool
         $counts = [];
 
         foreach ($this->workers as $worker) {
-            if (! $worker->isRunning() || ! $worker->isGroupWorker() || $worker->group === null) {
+            if (! $worker->isRunning() || $worker->isTerminating() || ! $worker->isGroupWorker() || $worker->group === null) {
                 continue;
             }
 
@@ -176,12 +176,36 @@ final class WorkerPool
         );
     }
 
+    /** @return Collection<int, WorkerProcess> */
+    public function getTerminatingWorkers(): Collection
+    {
+        return $this->workers->filter(
+            fn (WorkerProcess $w) => $w->isTerminating() && $w->isRunning()
+        );
+    }
+
     /** @return array<int, WorkerProcess> */
     public function getByConnection(string $connection, string $queue): array
     {
         return $this->workers->filter(
             fn (WorkerProcess $w) => $w->matches($connection, $queue)
         )->values()->all();
+    }
+
+    /** @return Collection<int, WorkerProcess> */
+    public function getTerminatable(string $connection, string $queue, int $count): Collection
+    {
+        return $this->workers->filter(
+            fn (WorkerProcess $w) => $w->matches($connection, $queue) && $w->isRunning() && ! $w->isTerminating()
+        )->take($count);
+    }
+
+    /** @return Collection<int, WorkerProcess> */
+    public function getTerminatableFromGroup(string $connection, string $group, int $count): Collection
+    {
+        return $this->workers->filter(
+            fn (WorkerProcess $w) => $w->matchesGroup($connection, $group) && $w->isRunning() && ! $w->isTerminating()
+        )->take($count);
     }
 
     /**

--- a/src/Workers/WorkerProcess.php
+++ b/src/Workers/WorkerProcess.php
@@ -9,6 +9,10 @@ use Symfony\Component\Process\Process;
 
 final class WorkerProcess
 {
+    private ?Carbon $terminationRequestedAt = null;
+
+    private ?Carbon $terminationDeadline = null;
+
     /**
      * @param  string  $queue  For per-queue workers this is the queue name; for group workers it is the
      *                         comma-separated queue list exactly as passed to `queue:work --queue=`.
@@ -35,6 +39,22 @@ final class WorkerProcess
     public function isDead(): bool
     {
         return ! $this->process->isRunning();
+    }
+
+    public function isTerminating(): bool
+    {
+        return $this->terminationRequestedAt !== null;
+    }
+
+    public function markTerminationRequested(Carbon $requestedAt, int $timeoutSeconds): void
+    {
+        $this->terminationRequestedAt = $requestedAt;
+        $this->terminationDeadline = $requestedAt->copy()->addSeconds(max($timeoutSeconds, 0));
+    }
+
+    public function terminationDeadlinePassed(Carbon $now): bool
+    {
+        return $this->terminationDeadline !== null && $now->greaterThanOrEqualTo($this->terminationDeadline);
     }
 
     public function uptimeSeconds(): int

--- a/src/Workers/WorkerTerminator.php
+++ b/src/Workers/WorkerTerminator.php
@@ -9,6 +9,63 @@ use Illuminate\Support\Facades\Log;
 
 final readonly class WorkerTerminator
 {
+    public function requestTermination(WorkerProcess $worker): bool
+    {
+        if ($worker->isTerminating()) {
+            return true;
+        }
+
+        $pid = $worker->pid();
+
+        if ($pid === null || ! $worker->isRunning()) {
+            return true;
+        }
+
+        if (! posix_kill($pid, SIGTERM)) {
+            Log::channel(AutoscaleConfiguration::logChannel())->warning(
+                'Failed to send SIGTERM to worker',
+                ['pid' => $pid]
+            );
+
+            return false;
+        }
+
+        $worker->markTerminationRequested(now(), AutoscaleConfiguration::shutdownTimeoutSeconds());
+
+        Log::channel(AutoscaleConfiguration::logChannel())->info(
+            'Worker termination requested',
+            ['pid' => $pid]
+        );
+
+        return true;
+    }
+
+    public function forceKillIfExpired(WorkerProcess $worker): bool
+    {
+        if (! $worker->isTerminating()) {
+            return false;
+        }
+
+        $pid = $worker->pid();
+
+        if ($pid === null || ! $worker->isRunning()) {
+            return false;
+        }
+
+        if (! $worker->terminationDeadlinePassed(now())) {
+            return false;
+        }
+
+        Log::channel(AutoscaleConfiguration::logChannel())->warning(
+            'Worker termination deadline exceeded, sending SIGKILL',
+            ['pid' => $pid]
+        );
+
+        posix_kill($pid, SIGKILL);
+
+        return true;
+    }
+
     /**
      * Terminate a worker process gracefully (SIGTERM then SIGKILL)
      *

--- a/tests/Unit/Manager/WorkerTerminationTest.php
+++ b/tests/Unit/Manager/WorkerTerminationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerPool;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerProcess;
+use Illuminate\Support\Facades\Event;
+use Symfony\Component\Process\Process;
+
+function workerTerminationPool(AutoscaleManager $manager): WorkerPool
+{
+    $property = new ReflectionProperty($manager, 'pool');
+
+    return $property->getValue($manager);
+}
+
+it('requests scale-down termination without using the blocking terminator path', function () {
+    config()->set('queue-autoscale.workers.shutdown_timeout_seconds', 2);
+    Event::fake();
+
+    $manager = app(AutoscaleManager::class);
+    $pool = workerTerminationPool($manager);
+    $process = new Process([
+        PHP_BINARY,
+        '-r',
+        'pcntl_async_signals(true); pcntl_signal(SIGTERM, function () {}); while (true) { usleep(100000); }',
+    ]);
+    $process->start();
+    usleep(100_000);
+    $pool->add(new WorkerProcess(
+        process: $process,
+        connection: 'redis',
+        queue: 'default',
+        spawnedAt: now(),
+    ));
+
+    $decision = new ScalingDecision(
+        connection: 'redis',
+        queue: 'default',
+        currentWorkers: 1,
+        targetWorkers: 0,
+        reason: 'test:scale_down',
+    );
+
+    $method = new ReflectionMethod($manager, 'scaleDown');
+    $start = microtime(true);
+    $method->invoke($manager, $decision);
+    $elapsed = microtime(true) - $start;
+
+    expect($pool->count('redis', 'default'))->toBe(0)
+        ->and($pool->getTerminatingWorkers())->toHaveCount(1)
+        ->and($elapsed)->toBeLessThan(1.0);
+
+    $process->stop(0, SIGKILL);
+});
+
+it('enforces termination deadlines on workers already shutting down', function () {
+    $manager = app(AutoscaleManager::class);
+    $pool = workerTerminationPool($manager);
+    $process = new Process(['sleep', '5']);
+    $process->start();
+    $worker = new WorkerProcess(
+        process: $process,
+        connection: 'redis',
+        queue: 'default',
+        spawnedAt: now(),
+    );
+    $worker->markTerminationRequested(now()->subSeconds(31), 30);
+    $pool->add($worker);
+
+    $method = new ReflectionMethod($manager, 'enforceTerminationDeadlines');
+    $method->invoke($manager);
+
+    usleep(100_000);
+
+    expect($process->isRunning())->toBeFalse();
+});

--- a/tests/Unit/Workers/WorkerPoolTest.php
+++ b/tests/Unit/Workers/WorkerPoolTest.php
@@ -186,3 +186,30 @@ test('totalCount counts group and per-queue workers together', function () {
 
     expect($this->pool->totalCount())->toBe(2);
 });
+
+test('terminating workers stay tracked but do not count as active capacity', function () {
+    $worker = createMockWorker('redis', 'default', 6001);
+    $worker->markTerminationRequested(now(), 30);
+
+    $this->pool->add($worker);
+
+    expect($this->pool->all())->toHaveCount(1)
+        ->and($this->pool->getTerminatingWorkers())->toHaveCount(1)
+        ->and($this->pool->count('redis', 'default'))->toBe(0)
+        ->and($this->pool->totalCount())->toBe(0)
+        ->and($this->pool->queueCounts())->toBe([]);
+});
+
+test('terminatable workers exclude workers already shutting down', function () {
+    $terminating = createMockWorker('redis', 'default', 7001);
+    $terminating->markTerminationRequested(now(), 30);
+    $active = createMockWorker('redis', 'default', 7002);
+
+    $this->pool->add($terminating);
+    $this->pool->add($active);
+
+    $terminatable = $this->pool->getTerminatable('redis', 'default', 2);
+
+    expect($terminatable)->toHaveCount(1)
+        ->and($terminatable->first())->toBe($active);
+});

--- a/tests/Unit/Workers/WorkerTerminatorTest.php
+++ b/tests/Unit/Workers/WorkerTerminatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Workers\WorkerProcess;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerTerminator;
+use Symfony\Component\Process\Process;
+
+it('requests worker termination without waiting for the shutdown timeout', function () {
+    config()->set('queue-autoscale.workers.shutdown_timeout_seconds', 30);
+
+    $process = new Process(['sleep', '5']);
+    $process->start();
+
+    $worker = new WorkerProcess(
+        process: $process,
+        connection: 'redis',
+        queue: 'default',
+        spawnedAt: now(),
+    );
+
+    $start = microtime(true);
+    $result = (new WorkerTerminator)->requestTermination($worker);
+    $elapsed = microtime(true) - $start;
+
+    expect($result)->toBeTrue()
+        ->and($worker->isTerminating())->toBeTrue()
+        ->and($elapsed)->toBeLessThan(1.0);
+
+    $process->stop(0);
+});


### PR DESCRIPTION
## Summary
- Keep scale-down from blocking the autoscale manager loop while workers drain.
- Mark workers as terminating after SIGTERM and exclude them from active worker counts.
- Keep terminating workers tracked so the manager can force-kill them after the shutdown timeout.
- Surface terminating workers in output status and add regression coverage around scale-down/termination behavior.

## Root Cause
Scale-down previously called the blocking terminator path for each worker. A worker that ignored SIGTERM could hold the manager loop for the full shutdown timeout per worker, delaying heartbeats, leader renewal, metrics refresh, and follow-up scaling decisions.

## Validation
- `vendor/bin/pest tests/Unit/Workers/WorkerPoolTest.php tests/Unit/Workers/WorkerTerminatorTest.php tests/Unit/Manager/WorkerTerminationTest.php tests/Unit/Manager/SuperviseQueueClusterTest.php tests/Unit/WorkerManagementTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`
