### PR TITLE
Refresh capacity each evaluation cycle

### DIFF
--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -263,6 +263,8 @@ final class AutoscaleManager
 
     private function runClusterCycle(): void
     {
+        $this->beginEvaluationCycle();
+
         $capacity = $this->capacity->calculateMaxWorkers(
             $this->pool->totalCount(),
             ResourceEstimate::globalDefault(),
@@ -1092,8 +1094,15 @@ final class AutoscaleManager
         return InstalledVersions::getPrettyVersion('cboxdk/laravel-queue-autoscale') ?? 'unknown';
     }
 
+    private function beginEvaluationCycle(): void
+    {
+        $this->capacity->invalidateCache();
+    }
+
     private function evaluateAndScale(): void
     {
+        $this->beginEvaluationCycle();
+
         // Recalculate metrics first to ensure throughput uses current sliding window
         app(CalculateQueueMetricsAction::class)->executeForAllQueues();
 

--- a/tests/Unit/Manager/CapacityRefreshTest.php
+++ b/tests/Unit/Manager/CapacityRefreshTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterStore;
+use Cbox\LaravelQueueAutoscale\Manager\AutoscaleManager;
+use Cbox\LaravelQueueAutoscale\Manager\SignalHandler;
+use Cbox\LaravelQueueAutoscale\Policies\PolicyExecutor;
+use Cbox\LaravelQueueAutoscale\Scaling\Calculators\CapacityCalculator;
+use Cbox\LaravelQueueAutoscale\Scaling\ResourceEstimateResolver;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingEngine;
+use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerSpawner;
+use Cbox\LaravelQueueAutoscale\Workers\WorkerTerminator;
+
+final class RecordingEvaluationCapacityCalculator extends CapacityCalculator
+{
+    public int $invalidations = 0;
+
+    public function invalidateCache(): void
+    {
+        $this->invalidations++;
+
+        parent::invalidateCache();
+    }
+}
+
+function makeManagerWithCapacity(CapacityCalculator $capacity): AutoscaleManager
+{
+    return new AutoscaleManager(
+        engine: app(ScalingEngine::class),
+        spawner: app(WorkerSpawner::class),
+        terminator: app(WorkerTerminator::class),
+        policies: app(PolicyExecutor::class),
+        signals: app(SignalHandler::class),
+        restartSignal: app(RestartSignal::class),
+        clusterStore: app(ClusterStore::class),
+        capacity: $capacity,
+        resolver: app(ResourceEstimateResolver::class),
+    );
+}
+
+function invokeBeginEvaluationCycle(AutoscaleManager $manager): void
+{
+    $method = new ReflectionMethod($manager, 'beginEvaluationCycle');
+    $method->invoke($manager);
+}
+
+it('starts evaluation cycles with a fresh capacity snapshot', function (): void {
+    $capacity = new RecordingEvaluationCapacityCalculator;
+    $manager = makeManagerWithCapacity($capacity);
+
+    invokeBeginEvaluationCycle($manager);
+    invokeBeginEvaluationCycle($manager);
+
+    expect($capacity->invalidations)->toBe(2);
+});


### PR DESCRIPTION
## Summary
- Refresh the capacity calculator snapshot at the start of every autoscale evaluation cycle.
- Keep intra-cycle capacity calls cached, so queue evaluations still share one CPU/memory measurement.
- Add regression coverage for the evaluation-cycle refresh hook.

## Root Cause
CapacityCalculator caches system metrics for up to four seconds to avoid repeated one-second CPU samples during a cycle. The manager never invalidated that cache at cycle boundaries, so short evaluation intervals could make several scaling decisions from the same CPU/memory snapshot and delay correction after worker count or load changed.

## Validation
- `vendor/bin/pest tests/Unit/Manager/CapacityRefreshTest.php tests/Unit/CapacityCalculatorTest.php tests/Unit/ScalingEngineTest.php tests/Unit/Manager/SuperviseQueueClusterTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`
