### PR TITLE
Make spawn latency EMA updates atomic

### DIFF
--- a/src/Workers/SpawnLatency/EmaSpawnLatencyTracker.php
+++ b/src/Workers/SpawnLatency/EmaSpawnLatencyTracker.php
@@ -6,6 +6,8 @@ namespace Cbox\LaravelQueueAutoscale\Workers\SpawnLatency;
 
 use Cbox\LaravelQueueAutoscale\Configuration\SpawnCompensationConfiguration;
 use Cbox\LaravelQueueAutoscale\Contracts\SpawnLatencyTrackerContract;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Facades\Redis;
 
 final class EmaSpawnLatencyTracker implements SpawnLatencyTrackerContract
@@ -62,22 +64,13 @@ final class EmaSpawnLatencyTracker implements SpawnLatencyTrackerContract
             ? $storedAlpha
             : $this->alpha;
 
-        /*
-         * NOTE: Read-modify-write of the EMA key is non-atomic.
-         * Concurrent first-pickups from multiple workers on the same queue
-         * can lose samples (last-write-wins). This is tolerable because the
-         * EMA is a smoothed signal; one lost sample doesn't degrade accuracy
-         * meaningfully. If that guarantee is insufficient, wrap the update
-         * in a Redis EVAL (Lua) or use WATCH/MULTI/EXEC.
-         */
-        $currentEma = Redis::get($emaKey);
-        $newEma = is_numeric($currentEma)
-            ? ($alpha * $latency) + ((1 - $alpha) * (float) $currentEma)
-            : $latency;
-
-        Redis::set($emaKey, (string) $newEma);
-        Redis::incr($countKey);
-        Redis::del($this->pendingKey($workerId));
+        $this->recordLatencyAtomically(
+            pendingKey: $this->pendingKey($workerId),
+            emaKey: $emaKey,
+            countKey: $countKey,
+            latency: $latency,
+            alpha: $alpha,
+        );
     }
 
     /**
@@ -114,5 +107,49 @@ final class EmaSpawnLatencyTracker implements SpawnLatencyTrackerContract
     private function countKey(string $connection, string $queue): string
     {
         return sprintf('autoscale:spawn:count:%s:%s', $connection, $queue);
+    }
+
+    private function recordLatencyAtomically(
+        string $pendingKey,
+        string $emaKey,
+        string $countKey,
+        float $latency,
+        float $alpha,
+    ): void {
+        $script = <<<'LUA'
+if redis.call('get', KEYS[1]) == false then
+    return 0
+end
+
+local current = tonumber(redis.call('get', KEYS[2]))
+local latency = tonumber(ARGV[1])
+local alpha = tonumber(ARGV[2])
+local next = latency
+
+if current ~= nil then
+    next = (alpha * latency) + ((1 - alpha) * current)
+end
+
+redis.call('set', KEYS[2], tostring(next))
+redis.call('incr', KEYS[3])
+redis.call('del', KEYS[1])
+
+return 1
+LUA;
+
+        $redis = $this->redis();
+
+        if ($redis instanceof PhpRedisConnection) {
+            $redis->command('eval', [$script, [$pendingKey, $emaKey, $countKey, (string) $latency, (string) $alpha], 3]);
+
+            return;
+        }
+
+        $redis->command('eval', [$script, 3, $pendingKey, $emaKey, $countKey, (string) $latency, (string) $alpha]);
+    }
+
+    private function redis(): Connection
+    {
+        return Redis::connection();
     }
 }

--- a/tests/Unit/CapacityCalculatorTest.php
+++ b/tests/Unit/CapacityCalculatorTest.php
@@ -258,5 +258,8 @@ it('uses per-queue memory estimate from ResourceEstimate', function () {
 
     if ($largeResult->maxWorkersByMemory > 0) {
         expect($smallResult->maxWorkersByMemory)->toBeGreaterThan($largeResult->maxWorkersByMemory);
+    } else {
+        expect($smallResult->details['memory_details']['worker_memory_mb'])->toBe(50.0)
+            ->and($largeResult->details['memory_details']['worker_memory_mb'])->toBe(2048.0);
     }
 });

--- a/tests/Unit/Workers/SpawnLatency/EmaSpawnLatencyTrackerTest.php
+++ b/tests/Unit/Workers/SpawnLatency/EmaSpawnLatencyTrackerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Cbox\LaravelQueueAutoscale\Configuration\SpawnCompensationConfiguration;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\EmaSpawnLatencyTracker;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Facades\Redis;
 
 // Returns a closure-based in-memory Redis fake for use with andReturnUsing.
@@ -21,6 +23,44 @@ function makeSpawnConfig(float $fallback = 2.5, int $minSamples = 5, float $alph
         minSamples: $minSamples,
         emaAlpha: $alpha,
     );
+}
+
+function mockAtomicSpawnLatencyUpdates(array &$store, int $times): void
+{
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('command')
+        ->times($times)
+        ->withArgs(function (string $method, array $parameters) use (&$store): bool {
+            expect($method)->toBe('eval');
+            expect($parameters)->toHaveCount(7);
+
+            [$script, $numberOfKeys, $pendingKey, $emaKey, $countKey, $latency, $alpha] = $parameters;
+
+            expect($script)->toContain("redis.call('incr'");
+            expect($numberOfKeys)->toBe(3);
+
+            if (! array_key_exists($pendingKey, $store)) {
+                return true;
+            }
+
+            $current = is_numeric($store[$emaKey] ?? null) ? (float) $store[$emaKey] : null;
+            $latency = (float) $latency;
+            $alpha = (float) $alpha;
+            $next = $current === null
+                ? $latency
+                : ($alpha * $latency) + ((1 - $alpha) * $current);
+
+            $store[$emaKey] = (string) $next;
+            $store[$countKey] = (string) ((int) ($store[$countKey] ?? 0) + 1);
+            unset($store[$pendingKey]);
+
+            return true;
+        })
+        ->andReturn(1);
+
+    Redis::shouldReceive('connection')
+        ->times($times)
+        ->andReturn($connection);
 }
 
 test('returns fallback when fewer than 5 samples recorded', function (): void {
@@ -88,6 +128,7 @@ test('converges toward true latency after multiple samples', function (): void {
 
             return 1;
         });
+    mockAtomicSpawnLatencyUpdates($store, 20);
 
     $tracker = new EmaSpawnLatencyTracker(alpha: 0.2);
     $config = makeSpawnConfig(fallback: 10.0, minSamples: 5, alpha: 0.2);
@@ -120,6 +161,48 @@ test('ignores pickup for unknown worker id', function (): void {
     $tracker->recordFirstPickup('nonexistent-worker', microtime(true));
 
     expect($tracker->currentLatency('redis', 'default', $config))->toBe(2.5);
+});
+
+test('updates ema through phpredis compatible eval arguments', function (): void {
+    $spawnTs = microtime(true) - 1.0;
+    $payload = json_encode([
+        'ts' => $spawnTs,
+        'connection' => 'redis',
+        'queue' => 'default',
+        'alpha' => 0.2,
+    ], JSON_THROW_ON_ERROR);
+
+    Redis::shouldReceive('get')
+        ->with('autoscale:spawn:pending:worker-1')
+        ->once()
+        ->andReturn($payload);
+
+    $connection = Mockery::mock(PhpRedisConnection::class);
+    $connection->shouldReceive('command')
+        ->once()
+        ->withArgs(function (string $method, array $parameters): bool {
+            expect($method)->toBe('eval');
+            expect($parameters)->toHaveCount(3);
+
+            [$script, $arguments, $numberOfKeys] = $parameters;
+
+            expect($script)->toContain("redis.call('incr'");
+            expect($arguments)->toHaveCount(5);
+            expect($arguments[0])->toBe('autoscale:spawn:pending:worker-1');
+            expect($arguments[1])->toBe('autoscale:spawn:ema:redis:default');
+            expect($arguments[2])->toBe('autoscale:spawn:count:redis:default');
+            expect($numberOfKeys)->toBe(3);
+
+            return true;
+        })
+        ->andReturn(1);
+
+    Redis::shouldReceive('connection')
+        ->once()
+        ->andReturn($connection);
+
+    $tracker = new EmaSpawnLatencyTracker(alpha: 0.2);
+    $tracker->recordFirstPickup('worker-1', $spawnTs + 1.0);
 });
 
 test('clamps extreme latencies into safe bounds', function (): void {
@@ -173,6 +256,7 @@ test('clamps extreme latencies into safe bounds', function (): void {
 
             return 1;
         });
+    mockAtomicSpawnLatencyUpdates($store, 3);
 
     // minSamples=1 and alpha=1.0 so the EMA becomes the last sample immediately.
     $tracker = new EmaSpawnLatencyTracker(alpha: 1.0);
@@ -239,6 +323,7 @@ test('isolates queues from one another', function (): void {
 
             return 1;
         });
+    mockAtomicSpawnLatencyUpdates($store, 10);
 
     $tracker = new EmaSpawnLatencyTracker(alpha: 0.2);
     $config = makeSpawnConfig(fallback: 2.5, minSamples: 5, alpha: 0.2);


### PR DESCRIPTION
## Summary
- Update spawn-latency EMA through a single Redis Lua operation instead of separate read/write commands.
- Preserve the phpredis-compatible eval argument shape used elsewhere in cluster coordination.
- Extend spawn-latency tests to cover atomic eval updates and phpredis argument handling.
- Stabilize a capacity calculator test so it always asserts even when the host has no available memory headroom.

## Root Cause
Concurrent first-pickup events on the same queue could read the same EMA value and then overwrite each other with last-write-wins updates. That could drop samples from the spawn compensation signal and make scale-up timing noisier under bursts.

## Validation
- `vendor/bin/pest tests/Unit/Workers/SpawnLatency/EmaSpawnLatencyTrackerTest.php tests/Feature/PickupTimeConfigBindingTest.php tests/Unit/Scaling/Strategies/HybridStrategyTest.php tests/Simulation/SpawnCompensationSimulationTest.php`
- `vendor/bin/pest tests/Unit/CapacityCalculatorTest.php tests/Unit/Workers/SpawnLatency/EmaSpawnLatencyTrackerTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse`
- `vendor/bin/pest`
