### PR TITLE
Weight cluster distribution by host capacity

### DIFF
--- a/src/Manager/AutoscaleManager.php
+++ b/src/Manager/AutoscaleManager.php
@@ -722,8 +722,9 @@ final class AutoscaleManager
             return $targets;
         }
 
-        // Reuse previous distribution when target is unchanged and all
-        // cached assignments still fit within each host's remaining capacity.
+        // Reuse previous distribution when target is unchanged, all cached
+        // assignments still fit within each host's remaining capacity, and the
+        // cached split is still balanced by host capacity.
         // This prevents worker pool thrashing caused by sort-order instability
         // when reported current counts fluctuate between heartbeats.
         $cached = $this->previousDistributions[$workloadKey] ?? null;
@@ -753,7 +754,7 @@ final class AutoscaleManager
                     }
                 }
 
-                if ($feasible) {
+                if ($feasible && $this->distributionIsCapacityBalanced($activeManagers, $cached, $assignedTotals)) {
                     foreach ($cached as $managerId => $cachedCount) {
                         $targets[$managerId] = $cachedCount;
                         $assignedTotals[$managerId] += $cachedCount;
@@ -772,35 +773,12 @@ final class AutoscaleManager
             $currentCounts[$state->managerId] = (int) ($counts["{$connection}:{$name}"] ?? 0);
         }
 
-        $preserveOrder = $activeManagers;
-        usort(
-            $preserveOrder,
-            fn (ClusterManagerState $a, ClusterManagerState $b): int => ($currentCounts[$b->managerId] <=> $currentCounts[$a->managerId])
-                ?: strcmp($a->managerId, $b->managerId),
-        );
-
         $remaining = $targetWorkers;
 
-        // Phase 1: Preserve existing workers on their current managers,
-        // but cap at each manager's reported capacity.
-        foreach ($preserveOrder as $state) {
-            if ($remaining <= 0) {
-                break;
-            }
-
-            $hostCapacity = max($state->maxWorkers - ($assignedTotals[$state->managerId] ?? 0), 0);
-            $keep = min($currentCounts[$state->managerId], $remaining, $hostCapacity);
-            $targets[$state->managerId] = $keep;
-            $assignedTotals[$state->managerId] += $keep;
-            $remaining -= $keep;
-        }
-
-        // Phase 2: Distribute remaining workers to least-loaded managers
-        // that still have capacity.
         while ($remaining > 0) {
             $candidates = array_values(array_filter(
                 $activeManagers,
-                fn (ClusterManagerState $state): bool => $assignedTotals[$state->managerId] < $state->maxWorkers,
+                fn (ClusterManagerState $state): bool => ($assignedTotals[$state->managerId] + $targets[$state->managerId]) < $state->maxWorkers,
             ));
 
             if ($candidates === []) {
@@ -809,21 +787,97 @@ final class AutoscaleManager
 
             usort(
                 $candidates,
-                fn (ClusterManagerState $a, ClusterManagerState $b): int => ($assignedTotals[$a->managerId] <=> $assignedTotals[$b->managerId])
-                    ?: ($a->totalWorkers <=> $b->totalWorkers)
+                fn (ClusterManagerState $a, ClusterManagerState $b): int => $this->projectedUtilizationAfterAssignment($a, $targets, $assignedTotals) <=> $this->projectedUtilizationAfterAssignment($b, $targets, $assignedTotals)
+                    ?: (($currentCounts[$b->managerId] - $targets[$b->managerId]) <=> ($currentCounts[$a->managerId] - $targets[$a->managerId]))
                     ?: strcmp($a->managerId, $b->managerId),
             );
 
             $chosen = $candidates[0];
 
             $targets[$chosen->managerId]++;
-            $assignedTotals[$chosen->managerId]++;
             $remaining--;
+        }
+
+        foreach ($targets as $managerId => $target) {
+            $assignedTotals[$managerId] += $target;
         }
 
         $this->previousDistributions[$workloadKey] = $targets;
 
         return $targets;
+    }
+
+    /**
+     * @param  array<int, ClusterManagerState>  $activeManagers
+     * @param  array<string, int>  $distribution
+     * @param  array<string, int>  $assignedTotals
+     */
+    private function distributionIsCapacityBalanced(array $activeManagers, array $distribution, array $assignedTotals): bool
+    {
+        $currentSpread = $this->distributionUtilizationSpread($activeManagers, $distribution, $assignedTotals);
+
+        foreach ($activeManagers as $donor) {
+            $donorId = $donor->managerId;
+
+            if (($distribution[$donorId] ?? 0) <= 0) {
+                continue;
+            }
+
+            foreach ($activeManagers as $recipient) {
+                $recipientId = $recipient->managerId;
+
+                if ($recipientId === $donorId) {
+                    continue;
+                }
+
+                if ((($assignedTotals[$recipientId] ?? 0) + ($distribution[$recipientId] ?? 0)) >= $recipient->maxWorkers) {
+                    continue;
+                }
+
+                $candidate = $distribution;
+                $candidate[$donorId]--;
+                $candidate[$recipientId]++;
+
+                if ($this->distributionUtilizationSpread($activeManagers, $candidate, $assignedTotals) + 0.000001 < $currentSpread) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<int, ClusterManagerState>  $activeManagers
+     * @param  array<string, int>  $distribution
+     * @param  array<string, int>  $assignedTotals
+     */
+    private function distributionUtilizationSpread(array $activeManagers, array $distribution, array $assignedTotals): float
+    {
+        $min = null;
+        $max = null;
+
+        foreach ($activeManagers as $state) {
+            $utilization = $this->utilizationFor($state, ($assignedTotals[$state->managerId] ?? 0) + ($distribution[$state->managerId] ?? 0));
+            $min = $min === null ? $utilization : min($min, $utilization);
+            $max = $max === null ? $utilization : max($max, $utilization);
+        }
+
+        return ($max ?? 0.0) - ($min ?? 0.0);
+    }
+
+    /**
+     * @param  array<string, int>  $targets
+     * @param  array<string, int>  $assignedTotals
+     */
+    private function projectedUtilizationAfterAssignment(ClusterManagerState $state, array $targets, array $assignedTotals): float
+    {
+        return $this->utilizationFor($state, ($assignedTotals[$state->managerId] ?? 0) + ($targets[$state->managerId] ?? 0) + 1);
+    }
+
+    private function utilizationFor(ClusterManagerState $state, int $workers): float
+    {
+        return $workers / max($state->maxWorkers, 1);
     }
 
     private function reconcileQueueTarget(QueueConfiguration $config, int $targetWorkers): void

--- a/tests/Unit/Cluster/ClusterDistributeTargetTest.php
+++ b/tests/Unit/Cluster/ClusterDistributeTargetTest.php
@@ -49,6 +49,24 @@ function invokeDistributeClusterTarget(array $managers, string $workloadKey, int
     return $method->invokeArgs($manager, [$managers, $workloadKey, $targetWorkers, &$assignedTotals]);
 }
 
+/**
+ * @param  array<int, ClusterManagerState>  $managers
+ * @param  array<string, int>  $assignedTotals
+ * @param  array<string, array<string, int>>  $previousDistributions
+ * @return array<string, int>
+ */
+function invokeDistributeClusterTargetWithCache(array $managers, string $workloadKey, int $targetWorkers, array &$assignedTotals, array $previousDistributions): array
+{
+    $manager = app(AutoscaleManager::class);
+
+    $property = new ReflectionProperty($manager, 'previousDistributions');
+    $property->setValue($manager, $previousDistributions);
+
+    $method = new ReflectionMethod($manager, 'distributeClusterTarget');
+
+    return $method->invokeArgs($manager, [$managers, $workloadKey, $targetWorkers, &$assignedTotals]);
+}
+
 it('caps assignments at per-host maxWorkers', function () {
     $small = makeManagerState('small', maxWorkers: 2);
     $large = makeManagerState('large', maxWorkers: 4);
@@ -76,7 +94,50 @@ it('distributes to least-loaded manager first', function () {
     expect($result['b'])->toBeGreaterThanOrEqual($result['a']);
 });
 
-it('skips full hosts in phase 2', function () {
+it('weights assignments by each host worker capacity', function () {
+    $small = makeManagerState('small', maxWorkers: 4);
+    $large = makeManagerState('large', maxWorkers: 8);
+    $managers = [$small, $large];
+
+    $assignedTotals = ['small' => 0, 'large' => 0];
+    $result = invokeDistributeClusterTarget($managers, 'queue:redis:fast', 6, $assignedTotals);
+
+    expect($result)->toBe([
+        'small' => 2,
+        'large' => 4,
+    ])->and($assignedTotals)->toBe([
+        'small' => 2,
+        'large' => 4,
+    ]);
+});
+
+it('rebalances cached assignments when host capacity changes the fair split', function () {
+    $small = makeManagerState('small', maxWorkers: 4);
+    $large = makeManagerState('large', maxWorkers: 8);
+    $managers = [$small, $large];
+    $workloadKey = 'queue:redis:fast';
+
+    $assignedTotals = ['small' => 0, 'large' => 0];
+    $result = invokeDistributeClusterTargetWithCache(
+        managers: $managers,
+        workloadKey: $workloadKey,
+        targetWorkers: 6,
+        assignedTotals: $assignedTotals,
+        previousDistributions: [
+            $workloadKey => [
+                'small' => 3,
+                'large' => 3,
+            ],
+        ],
+    );
+
+    expect($result)->toBe([
+        'small' => 2,
+        'large' => 4,
+    ]);
+});
+
+it('skips full hosts when assigning workers', function () {
     $full = makeManagerState('full', maxWorkers: 2);
     $available = makeManagerState('available', maxWorkers: 5);
     $managers = [$full, $available];
@@ -99,7 +160,7 @@ it('returns zero assignments when target is zero', function () {
     expect($result['a'])->toBe(0);
 });
 
-it('preserves existing workers in phase 1', function () {
+it('prefers preserving existing workers when utilization ties', function () {
     $a = makeManagerState('a', maxWorkers: 5, queueWorkers: ['redis:fast' => 2]);
     $b = makeManagerState('b', maxWorkers: 5, queueWorkers: ['redis:fast' => 1]);
     $managers = [$a, $b];
@@ -107,7 +168,6 @@ it('preserves existing workers in phase 1', function () {
     $assignedTotals = ['a' => 0, 'b' => 0];
     $result = invokeDistributeClusterTarget($managers, 'queue:redis:fast', 3, $assignedTotals);
 
-    // Should preserve existing: a=2, b=1
     expect($result['a'])->toBe(2)
         ->and($result['b'])->toBe(1);
 });


### PR DESCRIPTION
## Summary
- distribute cluster targets by projected host utilization instead of absolute worker count
- keep cached assignments only when they still fit and remain capacity-balanced
- add regression coverage for 4/8 capacity hosts producing a 2/4 split and for rebalancing stale 3/3 cached assignments

## Tests
- vendor/bin/pest tests/Unit/Cluster/ClusterDistributeTargetTest.php
- vendor/bin/pest tests/Unit/Cluster/ClusterFairShareIntegrationTest.php tests/Unit/Cluster/ClusterScalingDecisionsTest.php tests/Feature/ClusterRecommendationApplyTest.php
- vendor/bin/pint --dirty
- vendor/bin/phpstan analyse
- vendor/bin/pest