### PR TITLE
Honor Laravel queue:restart signal in the autoscale manager

### DIFF
--- a/config/queue-autoscale.php
+++ b/config/queue-autoscale.php
@@ -186,11 +186,16 @@ return [
     | restart_scope controls the cache key used by queue:autoscale:restart.
     | Leave unset unless multiple apps share the same cache backend.
     |
+    | honor_queue_restart makes the manager also exit gracefully when
+    | Laravel's own `php artisan queue:restart` signal is issued, so a
+    | standard deploy pipeline restarts the manager without extra steps.
+    |
     */
     'manager' => [
         'evaluation_interval_seconds' => 5,
         'log_channel' => env('QUEUE_AUTOSCALE_LOG_CHANNEL', 'stack'),
         'restart_scope' => env('QUEUE_AUTOSCALE_RESTART_SCOPE'),
+        'honor_queue_restart' => env('QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART', true),
     ],
 
     /*

--- a/docs/advanced-usage/deployment.md
+++ b/docs/advanced-usage/deployment.md
@@ -440,7 +440,7 @@ tail -f storage/logs/laravel.log | grep "WorkersScaled"
 # Status check
 sudo supervisorctl status queue-autoscale
 
-# Graceful restart on deploy
+# Graceful restart on deploy (php artisan queue:restart also works)
 php artisan queue:autoscale:restart
 
 # Force restart if the manager is wedged

--- a/docs/basic-usage/configuration.md
+++ b/docs/basic-usage/configuration.md
@@ -343,10 +343,13 @@ Balance based on:
     'evaluation_interval_seconds' => 5,
     'log_channel' => env('QUEUE_AUTOSCALE_LOG_CHANNEL', 'stack'),
     'restart_scope' => env('QUEUE_AUTOSCALE_RESTART_SCOPE'),
+    'honor_queue_restart' => env('QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART', true),
 ],
 ```
 
 `restart_scope` controls the cache key used by `php artisan queue:autoscale:restart`. Leave it unset for the default `app.name` + `app.env` scope. Set `QUEUE_AUTOSCALE_RESTART_SCOPE` when multiple apps share the same cache backend and need isolated restart signals.
+
+`honor_queue_restart` (default `true`) makes the manager also exit gracefully when Laravel's own `php artisan queue:restart` signal is issued, so standard deploy pipelines restart it automatically. Set it to `false` if `queue:restart` must only affect separately-supervised `queue:work` daemons. Note that `illuminate:queue:restart` is a global (unscoped) cache key — in multi-app setups sharing one cache backend, another app's `queue:restart` will also restart this manager; set `honor_queue_restart` to `false` (and use `queue:autoscale:restart` with `restart_scope`) to isolate.
 
 ## Advanced Options
 
@@ -442,6 +445,9 @@ QUEUE_AUTOSCALE_MANAGER_ID=web-01
 # Optional cache scope for php artisan queue:autoscale:restart.
 # Set this if multiple apps share the same cache backend.
 QUEUE_AUTOSCALE_RESTART_SCOPE=my-app-production
+
+# Set to false if php artisan queue:restart must NOT restart the manager
+QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART=true
 
 # Optional signal backends.
 # auto => null/no-op on single host, Redis-backed in cluster mode

--- a/docs/basic-usage/troubleshooting.md
+++ b/docs/basic-usage/troubleshooting.md
@@ -133,13 +133,13 @@ If neither applies, run `queue:autoscale:debug` for each member queue. If the me
 
 The manager is a long-running process — it holds the config in memory. It does not re-read the file.
 
-**Fix:** restart the manager. Every [platform deployment guide](../deployment/_index.md) covers the preferred deployment command:
+**Fix:** restart the manager. Your existing deploy script's `php artisan queue:restart` step is enough:
 
 ```bash
-php artisan queue:autoscale:restart
+php artisan queue:restart
 ```
 
-It lets the running manager drain spawned workers and exit. Your platform supervisor then starts the manager again from the current release. Use `supervisorctl restart` or `systemctl restart` only as manual fallbacks if the process is wedged.
+The manager honors the same signal on its next evaluation tick, gracefully terminates remaining workers, and exits. Your platform supervisor then starts it again from the current release. Alternatively, use `php artisan queue:autoscale:restart` if you run separately-supervised `queue:work` daemons. Use `supervisorctl restart` or `systemctl restart` only as manual fallbacks if the process is wedged.
 
 ## Two autoscalers are fighting each other
 

--- a/docs/deployment/_index.md
+++ b/docs/deployment/_index.md
@@ -20,7 +20,7 @@ The autoscaler manager (`php artisan queue:autoscale`) is a long-running daemon.
 - **Single-node or cluster mode.** By default, run one autoscaler. If you enable `queue-autoscale.cluster.enabled`, multiple managers can safely run against the same queues: they auto-join via Redis, elect a leader, and receive per-host worker recommendations.
 - **Graceful shutdown.** The manager catches `SIGTERM` and cleanly stops all spawned workers. Your platform should send SIGTERM, wait for `shutdown_timeout_seconds` (default 30), then SIGKILL.
 - **Don't double-configure workers.** If your platform has a "queue workers" section (Forge, Ploi) **do not** add entries for queues the autoscaler manages. The autoscaler IS your queue worker supervisor — the platform UI is for `queue:work` daemons that the autoscaler would fight with.
-- **Restart on deploy.** When your code changes, the manager must restart to pick up new code/config. Prefer `php artisan queue:autoscale:restart` in deploy hooks. It lets the running manager drain its spawned workers and exit, then your process supervisor starts it again from the new release.
+- **Restart on deploy.** When your code changes, the manager must restart to pick up new code/config. Your existing deploy script's `php artisan queue:restart` step is enough — the manager honors the same signal on its next evaluation tick and exits gracefully, then your process supervisor starts it again from the new release. Use `php artisan queue:autoscale:restart` only if you also run separately-supervised `queue:work` daemons that should keep running.
 
 ## Logs to keep an eye on
 

--- a/docs/deployment/forge.md
+++ b/docs/deployment/forge.md
@@ -35,15 +35,9 @@ You can keep Forge queue workers for queues you list in `queue-autoscale.exclude
 
 ## 3. Deploys
 
-Add this after the new release is active and migrations/config-cache steps are done:
+Forge's default deploy script already runs `php artisan queue:restart` (via "Restart Queue Workers") — that now also restarts the autoscale manager: it notices the signal on the next evaluation tick, gracefully stops spawned workers, and exits. Forge's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release. No extra deploy step is needed.
 
-```bash
-php artisan queue:autoscale:restart
-```
-
-The command works like Laravel's `queue:restart`: it writes a cache signal, the running autoscale manager notices it on the next evaluation tick, gracefully stops spawned workers, and exits. Forge's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release.
-
-For a manual graceful restart, run:
+To restart only the autoscale manager (leaving any separately-supervised workers alone), run:
 
 ```bash
 php artisan queue:autoscale:restart

--- a/docs/deployment/forge.md
+++ b/docs/deployment/forge.md
@@ -59,4 +59,4 @@ You should see `Autoscale manager started` shortly after deploy, then periodic w
 
 - **`.env` changes don't propagate** without a Daemon restart. Forge does this automatically after "Update Secrets" in the UI.
 - **PHP version mismatch.** Forge servers usually run multiple PHP versions. Make sure the Daemon command uses the same `php` binary your web layer uses (`php8.3` or similar if you pin a specific version).
-- **Long-running manager holds old code until restart.** A fresh deploy that changes scaling thresholds won't take effect until the Daemon restarts. Keep `php artisan queue:autoscale:restart` in the deploy script.
+- **Long-running manager holds old code until restart.** A fresh deploy that changes scaling thresholds won't take effect until the Daemon restarts. Forge's default `php artisan queue:restart` step already handles this.

--- a/docs/deployment/ploi.md
+++ b/docs/deployment/ploi.md
@@ -34,13 +34,13 @@ See [Queue Topology → Excluded Queues](../basic-usage/queue-topology.md#exclud
 
 ## 3. Deploys
 
-Add this near the end of your deploy script, after the new release is active and migrations/config-cache steps are done:
+Your standard deploy script's `php artisan queue:restart` step is enough — add it near the end, after the new release is active and migrations/config-cache are done:
 
 ```bash
-php artisan queue:autoscale:restart
+php artisan queue:restart
 ```
 
-The command writes a cache signal. The running autoscale manager sees it on the next evaluation tick, gracefully stops spawned workers, and exits. Ploi's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release.
+The running autoscale manager sees the signal on its next evaluation tick, gracefully stops spawned workers, and exits. Ploi's Daemon supervisor then relaunches `php artisan queue:autoscale` from the current release. Alternatively, use `php artisan queue:autoscale:restart` if you run separately-supervised `queue:work` daemons.
 
 For manual operations, you can still use Ploi's **Daemons → Restart** button or restart the daemon directly with Supervisor. Find the daemon ID in the Ploi UI or via `supervisorctl status`.
 

--- a/docs/deployment/self-hosted-vps.md
+++ b/docs/deployment/self-hosted-vps.md
@@ -82,17 +82,20 @@ sudo supervisorctl status queue-autoscale
 
 ## Zero-downtime deploys
 
-Your deploy script should trigger exactly one restart path:
+Either restart command works — most deploy scripts already run the first one:
 
 ```bash
-php artisan queue:autoscale:restart
+php artisan queue:restart            # standard Laravel deploy step, restarts workers AND the manager
+php artisan queue:autoscale:restart  # restarts only the autoscale manager
 ```
 
-`php artisan queue:autoscale:restart` works like Laravel's `queue:restart`: it writes a cache signal, the running manager notices it on the next evaluation tick, gracefully terminates all spawned `queue:work` processes, and exits. Your process supervisor then starts a fresh manager with the new code/config.
+Your existing deploy script's `php artisan queue:restart` step is enough: spawned workers finish their current job and exit, the manager notices the same signal on its next evaluation tick, gracefully terminates any remaining workers, and exits. Your process supervisor then starts a fresh manager with the new code/config.
+
+`php artisan queue:autoscale:restart` still works and restarts only the autoscale manager — useful when you also run separately-supervised `queue:work` daemons that should keep running.
 
 Direct `systemctl` / `supervisorctl` restarts are still fine as manual fallbacks; they send SIGTERM immediately, and the manager performs the same graceful shutdown path.
 
-**Do not also run `php artisan queue:restart`** — that's for separately-supervised `queue:work` daemons. Our spawned workers are killed directly when the manager shuts down.
+Set `QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART=false` to restore the old behaviour where only `queue:autoscale:restart` restarts the manager.
 
 ## Log rotation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,13 +230,7 @@ sudo supervisorctl update
 sudo supervisorctl start queue-autoscale:*
 ```
 
-On deploy, prefer the Artisan restart signal instead of restarting Supervisor directly:
-
-```bash
-php artisan queue:autoscale:restart
-```
-
-The manager drains its spawned workers, exits, and Supervisor starts it again from the new release.
+On deploy, use your standard `php artisan queue:restart` step. The manager honors the signal on its next evaluation tick and exits gracefully, then Supervisor starts it again from the new release. Alternatively, use `php artisan queue:autoscale:restart` if you run separately-supervised `queue:work` daemons.
 
 ## Verification
 

--- a/src/Configuration/AutoscaleConfiguration.php
+++ b/src/Configuration/AutoscaleConfiguration.php
@@ -81,6 +81,11 @@ final readonly class AutoscaleConfiguration
         return Str::slug($appName, '-').'-'.$appEnv;
     }
 
+    public static function honorQueueRestart(): bool
+    {
+        return (bool) config('queue-autoscale.manager.honor_queue_restart', true);
+    }
+
     public static function pickupTimeStore(): string
     {
         $configured = config('queue-autoscale.pickup_time.store', 'auto');

--- a/src/Support/RestartSignal.php
+++ b/src/Support/RestartSignal.php
@@ -24,6 +24,7 @@ final class RestartSignal
         $restartAt = max(
             $this->numericTimestamp(Cache::get($this->cacheKey())),
             $this->numericTimestamp(Cache::get($this->managerCacheKey())),
+            $this->laravelRestartTimestamp(),
         );
 
         return $restartAt > $timestamp;
@@ -42,6 +43,15 @@ final class RestartSignal
     private function numericTimestamp(mixed $value): int
     {
         return is_numeric($value) ? (int) $value : 0;
+    }
+
+    private function laravelRestartTimestamp(): int
+    {
+        if (! AutoscaleConfiguration::honorQueueRestart()) {
+            return 0;
+        }
+
+        return $this->numericTimestamp(Cache::get('illuminate:queue:restart')) * 1000;
     }
 
     private function currentTimestamp(): int

--- a/tests/Unit/Support/RestartSignalTest.php
+++ b/tests/Unit/Support/RestartSignalTest.php
@@ -56,3 +56,40 @@ it('ignores stale restart requests from before startup', function () {
 
     expect($signal->requestedAfter($startedAt))->toBeFalse();
 });
+
+it('detects a laravel queue:restart signal issued after startup', function () {
+    $signal = app(RestartSignal::class);
+    $startedAtMs = 1_000_000;
+
+    Cache::forever('illuminate:queue:restart', 2_000);
+
+    expect($signal->requestedAfter($startedAtMs))->toBeTrue();
+});
+
+it('ignores a laravel queue:restart signal from before startup', function () {
+    $signal = app(RestartSignal::class);
+    $startedAtMs = 3_000_000;
+
+    Cache::forever('illuminate:queue:restart', 2_000);
+
+    expect($signal->requestedAfter($startedAtMs))->toBeFalse();
+});
+
+it('ignores the laravel queue:restart signal when honor_queue_restart is disabled', function () {
+    config()->set('queue-autoscale.manager.honor_queue_restart', false);
+
+    $signal = app(RestartSignal::class);
+    $startedAtMs = 1_000_000;
+
+    Cache::forever('illuminate:queue:restart', 2_000);
+
+    expect($signal->requestedAfter($startedAtMs))->toBeFalse();
+});
+
+it('ignores non-numeric laravel queue:restart values', function () {
+    $signal = app(RestartSignal::class);
+
+    Cache::forever('illuminate:queue:restart', 'not-a-timestamp');
+
+    expect($signal->requestedAfter(0))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

The autoscale manager now also honors Laravel's native `php artisan queue:restart` cache signal (`illuminate:queue:restart`) and exits gracefully for a supervised restart — so a standard deploy pipeline restarts the manager without a package-specific step. Previously a forgotten `queue:autoscale:restart` after a symlink deploy left the manager (and every worker it respawns from the frozen `base_path`) running old code.

- `RestartSignal::requestedAfter()` also reads `illuminate:queue:restart` (unix seconds, normalized ×1000 to the package's millisecond scale)
- New config `manager.honor_queue_restart` / env `QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART` (default `true`) as escape hatch
- `queue:autoscale:restart` unchanged — still restarts only the manager (useful with separately-supervised `queue:work` daemons)
- Docs guidance reversed across nine files (the old "Do not also run `queue:restart`" warning is gone), including a note on the multi-app shared-cache footgun (`illuminate:queue:restart` is an unscoped key)

## ⚠️ Behavior change — release notes callout

**This should be a minor version bump.** After upgrading:

- Forge users: the default deploy script's "Restart Queue Workers" step now restarts the autoscale manager on every deploy (desired, but new behavior)
- Anyone deliberately running `queue:restart` for standalone workers while keeping the manager pinned must set `QUEUE_AUTOSCALE_HONOR_QUEUE_RESTART=false`

## Testing

- 4 new unit tests (signal after startup, stale signal before startup, toggle disabled, non-numeric cache value) using deterministic timestamps — Laravel's flag has second resolution vs the package's milliseconds
- Full suite: 589 passed (1871 assertions), PHPStan clean, Pint clean

## Review notes (non-blocking minors, logged)

- Sub-second blind spot: a `queue:restart` issued within the same wall-clock second as manager boot is missed (self-heals on next deploy); a capture-at-boot `!=` approach would fully match native worker semantics — possible follow-up
- Theoretical strict-types overflow on pathological cache values (≥ ~9.2e15)