### PR TITLE
Optional laravel-telemetry (OpenTelemetry) integration

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,15 +29,24 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
+          # Laravel 11 is still supported by this package (see require in
+          # composer.json), but cboxdk/laravel-telemetry needs illuminate
+          # ^12/^13, so this leg drops the telemetry dev dependency before
+          # installing and exercises the "telemetry not installed" path.
+          - laravel: 11.*
+            testbench: 9.*
+            php: 8.3
+            stability: prefer-stable
+            os: ubuntu-latest
         exclude:
-          # Exclude prefer-lowest combinations that have Orchestra Testbench incompatibilities
+          # PHP 8.4/8.5 + prefer-lowest are excluded pending separate
+          # verification; only the PHP 8.3 lowest-bound leg (L12.*) has been
+          # confirmed to resolve cleanly since Laravel 11 was dropped from the
+          # generated axis (`composer update --prefer-lowest --dry-run`,
+          # verified 2026-07-06).
           - php: 8.5
             stability: prefer-lowest
           - php: 8.4
-            stability: prefer-lowest
-          - laravel: 13.*
-            stability: prefer-lowest
-          - laravel: 12.*
             stability: prefer-lowest
           # spatie/laravel-prometheus ^13.0 support requires PHP 8.4+
           - php: 8.3
@@ -71,6 +80,10 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Remove telemetry integration (unsupported on Laravel 11)
+        if: matrix.laravel == '11.*'
+        run: composer remove --dev cboxdk/laravel-telemetry --no-update --no-interaction
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,15 +22,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [13.*, 12.*, 11.*]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 13.*
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
         exclude:
           # Exclude prefer-lowest combinations that have Orchestra Testbench incompatibilities
           - php: 8.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,15 @@ jobs:
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
+          # Laravel 11 is still supported by this package (see require in
+          # composer.json), but cboxdk/laravel-telemetry needs illuminate
+          # ^12/^13, so this leg drops the telemetry dev dependency before
+          # installing and exercises the "telemetry not installed" path.
+          - laravel: 11.*
+            testbench: 9.*
+            php: 8.3
+            stability: prefer-stable
+            os: ubuntu-latest
         exclude:
           # spatie/laravel-prometheus ^13.0 support requires PHP 8.4+
           - php: 8.3
@@ -54,6 +63,10 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Remove telemetry integration (unsupported on Laravel 11)
+        if: matrix.laravel == '11.*'
+        run: composer remove --dev cboxdk/laravel-telemetry --no-update --no-interaction
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,13 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php: [ 8.4, 8.3 ]
-        laravel: [ 13.*, 12.*, 11.* ]
+        laravel: [ 13.*, 12.* ]
         stability: [ prefer-stable ]
         include:
           - laravel: 13.*
             testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
-            testbench: 9.*
         exclude:
           # spatie/laravel-prometheus ^13.0 support requires PHP 8.4+
           - php: 8.3

--- a/README.md
+++ b/README.md
@@ -495,6 +495,35 @@ foreach ($allQueues as $queue) {
 - ✅ Enforces resource constraints (CPU/memory limits)
 - ✅ Executes scaling policies and broadcasts events
 
+## OpenTelemetry via laravel-telemetry
+
+When [`cboxdk/laravel-telemetry`](https://github.com/cboxdk/laravel-telemetry) is installed, the autoscaler automatically publishes its scaling signals — no configuration needed. Disable with `QUEUE_AUTOSCALE_TELEMETRY_ENABLED=false`.
+
+| Metric | Type | Unit | Labels |
+| --- | --- | --- | --- |
+| `queue_autoscale.workers.target` | gauge | `{workers}` | `connection`, `queue` |
+| `queue_autoscale.sla.predicted_pickup` | gauge | `s` | `connection`, `queue` |
+| `queue_autoscale.sla.target` | gauge | `s` | `connection`, `queue` |
+| `queue_autoscale.sla.breach` | gauge | `1` | `connection`, `queue` |
+| `queue_autoscale.capacity.max_workers` | gauge | `{workers}` | `limiter` |
+| `queue_autoscale.scaling.actions` | counter | `{actions}` | `connection`, `queue`, `direction` |
+| `queue_autoscale.sla.breaches` | counter | `{breaches}` | `connection`, `queue` |
+| `queue_autoscale.cluster.leader_changes` | counter | `{changes}` | — |
+| `queue_autoscale.cluster.managers` | gauge (observable) | `{managers}` | — |
+| `queue_autoscale.cluster.workers` | gauge (observable) | `{workers}` | — |
+| `queue_autoscale.cluster.required_workers` | gauge (observable) | `{workers}` | — |
+| `queue_autoscale.cluster.capacity` | gauge (observable) | `{workers}` | — |
+| `queue_autoscale.cluster.utilization` | gauge (observable) | `%` | — |
+| `queue_autoscale.cluster.recommended_hosts` | gauge (observable) | `{hosts}` | — |
+| `queue_autoscale.cluster.host.workers` | gauge (observable) | `{workers}` | `host` |
+| `queue_autoscale.cluster.host.capacity` | gauge (observable) | `{workers}` | `host` |
+
+Scaling actions, SLA breaches/recoveries, manager start/stop and cluster leader changes are also emitted as structured OTLP events (`queue_autoscale.scaling.action`, `queue_autoscale.sla.breached`, …) carrying the full context (including the scaling `reason`, which is deliberately not a metric label).
+
+Deliberately **not** exported: queue depth, oldest-job age, health scores, worker busy/idle state and job baselines (owned by `cboxdk/laravel-queue-metrics`), and per-job durations/outcomes (covered by laravel-telemetry's own queue instrumentation). There is no active-worker gauge here — join `queue_metrics.queue.active_workers` against `queue_autoscale.workers.target` in your dashboards. Spawn-latency gauges are a possible future addition.
+
+Note: metrics are shipped to your OTLP endpoint by the telemetry package's `telemetry:flush` (cron or `--daemon`) — make sure one is scheduled.
+
 ## Comparison with Horizon
 
 | Feature | Laravel Horizon | Queue Autoscale |

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ When [`cboxdk/laravel-telemetry`](https://github.com/cboxdk/laravel-telemetry) i
 
 Scaling actions, SLA breaches/recoveries, manager start/stop and cluster leader changes are also emitted as structured OTLP events (`queue_autoscale.scaling.action`, `queue_autoscale.sla.breached`, …) carrying the full context (including the scaling `reason`, which is deliberately not a metric label).
 
-Deliberately **not** exported: queue depth, oldest-job age, health scores, worker busy/idle state and job baselines (owned by `cboxdk/laravel-queue-metrics`), and per-job durations/outcomes (covered by laravel-telemetry's own queue instrumentation). There is no active-worker gauge here — join `queue_metrics.queue.active_workers` against `queue_autoscale.workers.target` in your dashboards. Spawn-latency gauges are a possible future addition.
+Deliberately **not** exported: queue depth, oldest-job age, health scores, worker busy/idle state and job baselines (owned by `cboxdk/laravel-queue-metrics`), and per-job durations/outcomes (covered by laravel-telemetry's own queue instrumentation). There is no active-worker gauge here — queue-metrics' own telemetry integration (its `queue_metrics.queue.active_workers` gauge, available from the queue-metrics release that ships telemetry support) is the one to join against `queue_autoscale.workers.target` in your dashboards. Spawn-latency gauges are a possible future addition.
 
 Note: metrics are shipped to your OTLP endpoint by the telemetry package's `telemetry:flush` (cron or `--daemon`) — make sure one is scheduled.
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,8 @@ foreach ($allQueues as $queue) {
 
 When [`cboxdk/laravel-telemetry`](https://github.com/cboxdk/laravel-telemetry) is installed, the autoscaler automatically publishes its scaling signals — no configuration needed. Disable with `QUEUE_AUTOSCALE_TELEMETRY_ENABLED=false`.
 
+`cboxdk/laravel-telemetry` requires Laravel 12+. This autoscaler package still supports Laravel 11, but the telemetry integration described below is simply unavailable there — `queue:autoscale:debug` reports `Telemetry: not installed` in that case.
+
 | Metric | Type | Unit | Labels |
 | --- | --- | --- | --- |
 | `queue_autoscale.workers.target` | gauge | `{workers}` | `connection`, `queue` |

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,10 @@
         "symfony/process": "^7.0||^8.0"
     },
     "require-dev": {
+        "cboxdk/laravel-telemetry": "^0.2.0",
+        "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.8",
-        "larastan/larastan": "^3.0",
         "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
@@ -40,6 +41,9 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"
+    },
+    "suggest": {
+        "cboxdk/laravel-telemetry": "Publishes scaling decisions, SLA breach state and cluster gauges to OpenTelemetry via the telemetry pipeline."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpstan/phpstan-phpunit": "^2.0"
     },
     "suggest": {
-        "cboxdk/laravel-telemetry": "Publishes scaling decisions, SLA breach state and cluster gauges to OpenTelemetry via the telemetry pipeline."
+        "cboxdk/laravel-telemetry": "Publishes scaling decisions, SLA breach state and cluster gauges to OpenTelemetry via the telemetry pipeline. Requires Laravel 12+; unavailable on Laravel 11."
     },
     "autoload": {
         "psr-4": {

--- a/config/queue-autoscale.php
+++ b/config/queue-autoscale.php
@@ -242,4 +242,28 @@ return [
     'alerting' => [
         'cooldown_seconds' => env('QUEUE_AUTOSCALE_ALERT_COOLDOWN', 300),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | 📡 TELEMETRY (cboxdk/laravel-telemetry)
+    |--------------------------------------------------------------------------
+    |
+    | When cboxdk/laravel-telemetry is installed, the autoscaler automatically
+    | publishes scaling gauges/counters and pushes domain events (scaling
+    | actions, SLA breaches, leader changes) to it, plus observable cluster
+    | gauges in cluster mode. Batteries included: on by default, no-op when
+    | the package is not installed.
+    |
+    */
+    'telemetry' => [
+        'enabled' => env('QUEUE_AUTOSCALE_TELEMETRY_ENABLED', true),
+
+        'cache_ttl' => env('QUEUE_AUTOSCALE_TELEMETRY_CACHE_TTL', 10),
+
+        'gauges' => [
+            'cluster' => true,
+        ],
+
+        'events' => true,
+    ],
 ];

--- a/src/Commands/DebugQueueCommand.php
+++ b/src/Commands/DebugQueueCommand.php
@@ -182,6 +182,10 @@ class DebugQueueCommand extends Command
             return 'not installed (composer require cboxdk/laravel-telemetry)';
         }
 
+        if (! $this->laravel->bound(TelemetryManager::class)) {
+            return 'installed but not booted (telemetry service provider not registered)';
+        }
+
         if (! config('queue-autoscale.telemetry.enabled', true)) {
             return 'disabled (queue-autoscale.telemetry.enabled)';
         }

--- a/src/Commands/DebugQueueCommand.php
+++ b/src/Commands/DebugQueueCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueAutoscale\Commands;
 
 use Cbox\LaravelQueueMetrics\Facades\QueueMetrics;
+use Cbox\Telemetry\TelemetryManager;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -27,6 +28,9 @@ class DebugQueueCommand extends Command
         $connection = is_string($connectionOpt) && $connectionOpt !== '' ? $connectionOpt : $fallback;
 
         $this->info("Debugging queue: {$connection}:{$queue}");
+        $this->line('');
+
+        $this->line('Telemetry: '.$this->describeTelemetryIntegration());
         $this->line('');
 
         // Get queue depth from metrics package
@@ -170,5 +174,22 @@ class DebugQueueCommand extends Command
                 [$delayedKey, 'ZSET', (string) $redis->zcard($delayedKey)],
             ]
         );
+    }
+
+    private function describeTelemetryIntegration(): string
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            return 'not installed (composer require cboxdk/laravel-telemetry)';
+        }
+
+        if (! config('queue-autoscale.telemetry.enabled', true)) {
+            return 'disabled (queue-autoscale.telemetry.enabled)';
+        }
+
+        if (! config('telemetry.enabled', true)) {
+            return 'inactive (telemetry.enabled is false)';
+        }
+
+        return 'active';
     }
 }

--- a/src/LaravelQueueAutoscaleServiceProvider.php
+++ b/src/LaravelQueueAutoscaleServiceProvider.php
@@ -219,7 +219,11 @@ class LaravelQueueAutoscaleServiceProvider extends ServiceProvider
      * listeners that resolve `TelemetryManager` from the container at
      * dispatch time and blow up with a `BindingResolutionException` in any
      * app that has the dependency present but hasn't booted its service
-     * provider (e.g. a narrower test harness).
+     * provider (e.g. a narrower test harness). The bound() guard covers the
+     * subscription because event handlers resolve `TelemetryManager` per call,
+     * gated only by `queue-autoscale.telemetry.events` (default true) — with
+     * the class present but unbound, a dispatched event would otherwise crash
+     * the queue manager.
      *
      * `TelemetryEventSubscriber` holds mutable debounce state, so it must be
      * bound as a container singleton before `Event::subscribe()` registers

--- a/src/LaravelQueueAutoscaleServiceProvider.php
+++ b/src/LaravelQueueAutoscaleServiceProvider.php
@@ -37,14 +37,18 @@ use Cbox\LaravelQueueAutoscale\Scaling\ScalingEngine;
 use Cbox\LaravelQueueAutoscale\Support\ManagerProcessLock;
 use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
 use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\QueueAutoscaleTelemetryProvider;
 use Cbox\LaravelQueueAutoscale\Telemetry\QueueAutoscaleTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\EmaSpawnLatencyTracker;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\NullSpawnLatencyTracker;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\SpawnLatencyRecorder;
 use Cbox\LaravelQueueAutoscale\Workers\WorkerSpawner;
 use Cbox\LaravelQueueAutoscale\Workers\WorkerTerminator;
+use Cbox\Telemetry\TelemetryManager;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelQueueAutoscaleServiceProvider extends ServiceProvider
@@ -175,6 +179,8 @@ class LaravelQueueAutoscaleServiceProvider extends ServiceProvider
             JobProcessing::class,
             SpawnLatencyRecorder::class,
         );
+
+        $this->registerTelemetryIntegration();
     }
 
     private function resolvePickupTimeStoreClass(): string
@@ -203,5 +209,44 @@ class LaravelQueueAutoscaleServiceProvider extends ServiceProvider
             'null' => NullSpawnLatencyTracker::class,
             default => $configured,
         };
+    }
+
+    /**
+     * Optional integration with cboxdk/laravel-telemetry: no-op unless the
+     * package is installed, enabled via config, and its manager is actually
+     * bound in the container. That last check matters even when the class
+     * exists: without it, subscribing to package events here would register
+     * listeners that resolve `TelemetryManager` from the container at
+     * dispatch time and blow up with a `BindingResolutionException` in any
+     * app that has the dependency present but hasn't booted its service
+     * provider (e.g. a narrower test harness).
+     *
+     * `TelemetryEventSubscriber` holds mutable debounce state, so it must be
+     * bound as a container singleton before `Event::subscribe()` registers
+     * it — Laravel's array-map subscriber path resolves a fresh instance
+     * from the container on every dispatch unless the class itself is a
+     * singleton.
+     */
+    protected function registerTelemetryIntegration(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            return;
+        }
+
+        if (! config('queue-autoscale.telemetry.enabled', true)) {
+            return;
+        }
+
+        if (! $this->app->bound(TelemetryManager::class)) {
+            return;
+        }
+
+        $this->app->make(TelemetryManager::class)->provider(
+            new QueueAutoscaleTelemetryProvider($this->app),
+        );
+
+        $this->app->singleton(TelemetryEventSubscriber::class);
+
+        Event::subscribe(TelemetryEventSubscriber::class);
     }
 }

--- a/src/LaravelQueueAutoscaleServiceProvider.php
+++ b/src/LaravelQueueAutoscaleServiceProvider.php
@@ -36,6 +36,8 @@ use Cbox\LaravelQueueAutoscale\Scaling\ResourceEstimateResolver;
 use Cbox\LaravelQueueAutoscale\Scaling\ScalingEngine;
 use Cbox\LaravelQueueAutoscale\Support\ManagerProcessLock;
 use Cbox\LaravelQueueAutoscale\Support\RestartSignal;
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\QueueAutoscaleTelemetrySnapshot;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\EmaSpawnLatencyTracker;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\NullSpawnLatencyTracker;
 use Cbox\LaravelQueueAutoscale\Workers\SpawnLatency\SpawnLatencyRecorder;
@@ -137,6 +139,12 @@ class LaravelQueueAutoscaleServiceProvider extends ServiceProvider
         $this->app->singleton(RestartSignal::class);
         $this->app->singleton(SignalHandler::class);
         $this->app->singleton(AutoscaleManager::class);
+
+        // Register telemetry snapshot
+        $this->app->singleton(
+            ProvidesTelemetrySnapshot::class,
+            QueueAutoscaleTelemetrySnapshot::class,
+        );
     }
 
     public function boot(): void

--- a/src/Telemetry/Contracts/ProvidesTelemetrySnapshot.php
+++ b/src/Telemetry/Contracts/ProvidesTelemetrySnapshot.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Telemetry\Contracts;
+
+/**
+ * Snapshot source consumed by the optional telemetry integration.
+ *
+ * Implementations must stay cheap: callbacks run on every telemetry scrape.
+ */
+interface ProvidesTelemetrySnapshot
+{
+    /**
+     * @return array{cluster: array<string, mixed>}
+     */
+    public function snapshot(): array;
+}

--- a/src/Telemetry/QueueAutoscaleTelemetryProvider.php
+++ b/src/Telemetry/QueueAutoscaleTelemetryProvider.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\Telemetry\Contracts\TelemetryProvider;
+use Cbox\Telemetry\Metrics\Registry;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Observable cluster gauges, evaluated at scrape time from the Redis-backed
+ * cluster summary. Deliberately limited to what only the autoscaler knows —
+ * queue depth, worker state and job metrics are owned by queue-metrics and
+ * telemetry's own queue instrumentation.
+ */
+final readonly class QueueAutoscaleTelemetryProvider implements TelemetryProvider
+{
+    public function __construct(private Container $container) {}
+
+    public function name(): string
+    {
+        return 'cbox.queue-autoscale';
+    }
+
+    public function register(Registry $registry): void
+    {
+        if (config('queue-autoscale.telemetry.gauges.cluster', true)) {
+            $this->registerClusterGauges($registry);
+        }
+    }
+
+    private function registerClusterGauges(Registry $registry): void
+    {
+        $summaryGauges = [
+            'queue_autoscale.cluster.managers' => ['manager_count', 'Active autoscale managers in the cluster', '{managers}'],
+            'queue_autoscale.cluster.workers' => ['total_workers', 'Autoscaler-spawned workers across the cluster', '{workers}'],
+            'queue_autoscale.cluster.required_workers' => ['required_workers', 'Cluster-wide worker demand', '{workers}'],
+            'queue_autoscale.cluster.capacity' => ['total_worker_capacity', 'Cluster-wide worker capacity', '{workers}'],
+            'queue_autoscale.cluster.utilization' => ['utilization_percent', 'Cluster worker capacity utilization', '%'],
+        ];
+
+        foreach ($summaryGauges as $name => [$key, $description, $unit]) {
+            $registry->gauge(
+                $name,
+                fn (): array => $this->summarySample($key),
+                description: $description,
+                unit: $unit,
+            );
+        }
+
+        $registry->gauge(
+            'queue_autoscale.cluster.recommended_hosts',
+            fn (): array => $this->nestedSample('scale_signal', 'recommended_hosts'),
+            description: 'Host count recommended by the cluster leader',
+            unit: '{hosts}',
+        );
+
+        $registry->gauge(
+            'queue_autoscale.cluster.host.workers',
+            fn (): array => $this->perHost('total_workers'),
+            description: 'Autoscaler-spawned workers per host',
+            unit: '{workers}',
+        );
+
+        $registry->gauge(
+            'queue_autoscale.cluster.host.capacity',
+            fn (): array => $this->perHost('max_workers'),
+            description: 'Worker capacity per host',
+            unit: '{workers}',
+        );
+    }
+
+    /**
+     * @return list<array{0: float, 1: array<string, string>}>
+     */
+    private function summarySample(string $key): array
+    {
+        $cluster = $this->cluster();
+
+        if ($cluster === []) {
+            return [];
+        }
+
+        return [[$this->toFloat($cluster[$key] ?? null), []]];
+    }
+
+    /**
+     * @return list<array{0: float, 1: array<string, string>}>
+     */
+    private function nestedSample(string $group, string $key): array
+    {
+        $cluster = $this->cluster();
+
+        if ($cluster === []) {
+            return [];
+        }
+
+        $nested = $cluster[$group] ?? null;
+
+        return [[$this->toFloat(is_array($nested) ? ($nested[$key] ?? null) : null), []]];
+    }
+
+    /**
+     * @return list<array{0: float, 1: array<string, string>}>
+     */
+    private function perHost(string $key): array
+    {
+        $managers = $this->cluster()['managers'] ?? null;
+
+        if (! is_array($managers)) {
+            return [];
+        }
+
+        $samples = [];
+
+        foreach ($managers as $manager) {
+            if (! is_array($manager)) {
+                continue;
+            }
+
+            $samples[] = [$this->toFloat($manager[$key] ?? null), ['host' => $this->toLabel($manager['host'] ?? null)]];
+        }
+
+        return $samples;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function cluster(): array
+    {
+        return $this->container->make(ProvidesTelemetrySnapshot::class)->snapshot()['cluster'];
+    }
+
+    private function toFloat(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+
+    private function toLabel(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : 'unknown';
+    }
+}

--- a/src/Telemetry/QueueAutoscaleTelemetrySnapshot.php
+++ b/src/Telemetry/QueueAutoscaleTelemetrySnapshot.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterStore;
+use Cbox\LaravelQueueAutoscale\Configuration\AutoscaleConfiguration;
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Default telemetry snapshot backed by the Redis cluster store.
+ *
+ * The snapshot is cached briefly so concurrent scrapes do not all hit the
+ * cluster store at once. Single-host mode yields an empty cluster snapshot.
+ */
+final readonly class QueueAutoscaleTelemetrySnapshot implements ProvidesTelemetrySnapshot
+{
+    public function __construct(private Container $container) {}
+
+    public function snapshot(): array
+    {
+        $cacheTtl = config('queue-autoscale.telemetry.cache_ttl', 10);
+        $cacheTtl = is_numeric($cacheTtl) ? (int) $cacheTtl : 10;
+
+        if ($cacheTtl <= 0) {
+            return $this->build();
+        }
+
+        return Cache::remember(
+            'queue_autoscale:telemetry:snapshot',
+            now()->addSeconds($cacheTtl),
+            fn (): array => $this->build(),
+        );
+    }
+
+    /**
+     * @return array{cluster: array<string, mixed>}
+     */
+    private function build(): array
+    {
+        if (! AutoscaleConfiguration::clusterEnabled()) {
+            return ['cluster' => []];
+        }
+
+        $store = $this->container->make(ClusterStore::class);
+        $summary = $store->summary();
+
+        return ['cluster' => $summary];
+    }
+}

--- a/src/Telemetry/TelemetryEventSubscriber.php
+++ b/src/Telemetry/TelemetryEventSubscriber.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStarted;
+use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStopped;
+use Cbox\LaravelQueueAutoscale\Events\ClusterLeaderChanged;
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Events\SlaBreached;
+use Cbox\LaravelQueueAutoscale\Events\SlaRecovered;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\Telemetry\TelemetryManager;
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Pushes autoscaler state to telemetry from the manager daemon. Push (not
+ * observable) gauges on purpose: the manager is long-running and standalone,
+ * so nothing else could evaluate a scrape callback for its in-memory state.
+ *
+ * Rare-but-important signals flush immediately — the daemon has no request
+ * terminate. The per-tick decision handler flushes at most once per second.
+ */
+final class TelemetryEventSubscriber
+{
+    private float $lastFlushAt = 0.0;
+
+    public function __construct(private readonly Container $container) {}
+
+    /**
+     * @return array<class-string, string>
+     */
+    public function subscribe(): array
+    {
+        return [
+            ScalingDecisionMade::class => 'handleScalingDecisionMade',
+            WorkersScaled::class => 'handleWorkersScaled',
+            SlaBreached::class => 'handleSlaBreached',
+            SlaRecovered::class => 'handleSlaRecovered',
+            AutoscaleManagerStarted::class => 'handleAutoscaleManagerStarted',
+            AutoscaleManagerStopped::class => 'handleAutoscaleManagerStopped',
+            ClusterLeaderChanged::class => 'handleClusterLeaderChanged',
+        ];
+    }
+
+    public function handleScalingDecisionMade(ScalingDecisionMade $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $decision = $event->decision;
+        $labels = ['connection' => $decision->connection, 'queue' => $decision->queue];
+
+        $telemetry->gauge('queue_autoscale.workers.target', description: 'Worker count the autoscaler is steering toward', unit: '{workers}')
+            ->set((float) $decision->targetWorkers, $labels);
+
+        $telemetry->gauge('queue_autoscale.sla.target', description: 'Configured SLA pickup target', unit: 's')
+            ->set((float) $decision->slaTarget, $labels);
+
+        if ($decision->predictedPickupTime !== null) {
+            $telemetry->gauge('queue_autoscale.sla.predicted_pickup', description: 'Predicted job pickup time', unit: 's')
+                ->set($decision->predictedPickupTime, $labels);
+        }
+
+        if ($decision->capacity !== null) {
+            $telemetry->gauge('queue_autoscale.capacity.max_workers', description: 'Host worker capacity ceiling', unit: '{workers}')
+                ->set((float) $decision->capacity->finalMaxWorkers, ['limiter' => $decision->capacity->limitingFactor]);
+        }
+
+        $this->flushDebounced($telemetry);
+    }
+
+    public function handleWorkersScaled(WorkersScaled $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $labels = ['connection' => $event->connection, 'queue' => $event->queue];
+
+        $telemetry->counter('queue_autoscale.scaling.actions', 'Executed scaling actions')
+            ->inc(1, [...$labels, 'direction' => $event->action]);
+
+        $telemetry->event('queue_autoscale.scaling.action', [
+            ...$labels,
+            'from' => $event->from,
+            'to' => $event->to,
+            'direction' => $event->action,
+            'reason' => $event->reason,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleSlaBreached(SlaBreached $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $labels = ['connection' => $event->connection, 'queue' => $event->queue];
+
+        $telemetry->gauge('queue_autoscale.sla.breach', description: 'Whether the queue is currently breaching its SLA', unit: '1')
+            ->set(1.0, $labels);
+
+        $telemetry->counter('queue_autoscale.sla.breaches', 'SLA breach transitions')
+            ->inc(1, $labels);
+
+        $telemetry->event('queue_autoscale.sla.breached', [
+            ...$labels,
+            'oldest_job_age' => $event->oldestJobAge,
+            'sla_target' => $event->slaTarget,
+            'breach_seconds' => $event->breachSeconds(),
+            'breach_percentage' => $event->breachPercentage(),
+            'pending' => $event->pending,
+            'active_workers' => $event->activeWorkers,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleSlaRecovered(SlaRecovered $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+        $labels = ['connection' => $event->connection, 'queue' => $event->queue];
+
+        $telemetry->gauge('queue_autoscale.sla.breach', description: 'Whether the queue is currently breaching its SLA', unit: '1')
+            ->set(0.0, $labels);
+
+        $telemetry->event('queue_autoscale.sla.recovered', [
+            ...$labels,
+            'current_job_age' => $event->currentJobAge,
+            'sla_target' => $event->slaTarget,
+            'margin_seconds' => $event->marginSeconds(),
+            'pending' => $event->pending,
+            'active_workers' => $event->activeWorkers,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleAutoscaleManagerStarted(AutoscaleManagerStarted $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+
+        $telemetry->event('queue_autoscale.manager.started', [
+            'manager_id' => $event->managerId,
+            'host' => $event->host,
+            'cluster_enabled' => $event->clusterEnabled,
+            'interval_seconds' => $event->intervalSeconds,
+            'package_version' => $event->packageVersion,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleAutoscaleManagerStopped(AutoscaleManagerStopped $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+
+        $telemetry->event('queue_autoscale.manager.stopped', [
+            'manager_id' => $event->managerId,
+            'host' => $event->host,
+            'reason' => $event->reason,
+            'worker_count' => $event->workerCount,
+            'uptime_seconds' => ($event->stoppedAt - $event->startedAt) / 1000.0,
+        ]);
+
+        $telemetry->flush();
+    }
+
+    public function handleClusterLeaderChanged(ClusterLeaderChanged $event): void
+    {
+        if (! $this->enabled()) {
+            return;
+        }
+
+        $telemetry = $this->telemetry();
+
+        $telemetry->counter('queue_autoscale.cluster.leader_changes', 'Cluster leader changes')
+            ->inc(1, []);
+
+        $telemetry->event('queue_autoscale.cluster.leader_changed', [
+            'cluster_id' => $event->clusterId,
+            'previous_leader_id' => $event->previousLeaderId ?? '',
+            'current_leader_id' => $event->currentLeaderId ?? '',
+        ]);
+
+        $telemetry->flush();
+    }
+
+    private function enabled(): bool
+    {
+        return (bool) config('queue-autoscale.telemetry.events', true);
+    }
+
+    private function telemetry(): TelemetryManager
+    {
+        return $this->container->make(TelemetryManager::class);
+    }
+
+    private function flushDebounced(TelemetryManager $telemetry): void
+    {
+        $nowSeconds = microtime(true);
+
+        if ($nowSeconds - $this->lastFlushAt < 1.0) {
+            return;
+        }
+
+        $this->lastFlushAt = $nowSeconds;
+        $telemetry->flush();
+    }
+}

--- a/src/Telemetry/TelemetryEventSubscriber.php
+++ b/src/Telemetry/TelemetryEventSubscriber.php
@@ -20,13 +20,25 @@ use Illuminate\Contracts\Container\Container;
  * so nothing else could evaluate a scrape callback for its in-memory state.
  *
  * Rare-but-important signals flush immediately — the daemon has no request
- * terminate. The per-tick decision handler flushes at most once per second.
+ * terminate. The per-tick decision handler flushes at most once per
+ * configured debounce window (one second by default).
+ *
+ * `Event::subscribe()` maps each listener to `[self::class, $method]` and
+ * lets the container resolve a fresh instance on every dispatch — it does
+ * NOT reuse the instance that registered the subscription. The debounce
+ * state above therefore only holds across dispatches because this class is
+ * bound as a container singleton (see the service provider); without that
+ * binding, every dispatch would construct a new instance with
+ * `$lastFlushAt = 0.0`, and every decision would flush.
  */
 final class TelemetryEventSubscriber
 {
     private float $lastFlushAt = 0.0;
 
-    public function __construct(private readonly Container $container) {}
+    public function __construct(
+        private readonly Container $container,
+        private readonly float $flushIntervalSeconds = 1.0,
+    ) {}
 
     /**
      * @return array<class-string, string>
@@ -82,7 +94,7 @@ final class TelemetryEventSubscriber
         $telemetry = $this->telemetry();
         $labels = ['connection' => $event->connection, 'queue' => $event->queue];
 
-        $telemetry->counter('queue_autoscale.scaling.actions', 'Executed scaling actions')
+        $telemetry->counter('queue_autoscale.scaling.actions', 'Executed scaling actions', unit: '{actions}')
             ->inc(1, [...$labels, 'direction' => $event->action]);
 
         $telemetry->event('queue_autoscale.scaling.action', [
@@ -108,7 +120,7 @@ final class TelemetryEventSubscriber
         $telemetry->gauge('queue_autoscale.sla.breach', description: 'Whether the queue is currently breaching its SLA', unit: '1')
             ->set(1.0, $labels);
 
-        $telemetry->counter('queue_autoscale.sla.breaches', 'SLA breach transitions')
+        $telemetry->counter('queue_autoscale.sla.breaches', 'SLA breach transitions', unit: '{breaches}')
             ->inc(1, $labels);
 
         $telemetry->event('queue_autoscale.sla.breached', [
@@ -160,6 +172,7 @@ final class TelemetryEventSubscriber
             'manager_id' => $event->managerId,
             'host' => $event->host,
             'cluster_enabled' => $event->clusterEnabled,
+            'cluster_id' => $event->clusterId,
             'interval_seconds' => $event->intervalSeconds,
             'package_version' => $event->packageVersion,
         ]);
@@ -194,7 +207,7 @@ final class TelemetryEventSubscriber
 
         $telemetry = $this->telemetry();
 
-        $telemetry->counter('queue_autoscale.cluster.leader_changes', 'Cluster leader changes')
+        $telemetry->counter('queue_autoscale.cluster.leader_changes', 'Cluster leader changes', unit: '{changes}')
             ->inc(1, []);
 
         $telemetry->event('queue_autoscale.cluster.leader_changed', [
@@ -220,7 +233,7 @@ final class TelemetryEventSubscriber
     {
         $nowSeconds = microtime(true);
 
-        if ($nowSeconds - $this->lastFlushAt < 1.0) {
+        if ($nowSeconds - $this->lastFlushAt < $this->flushIntervalSeconds) {
             return;
         }
 

--- a/tests/Feature/Telemetry/DebugCommandTelemetryTest.php
+++ b/tests/Feature/Telemetry/DebugCommandTelemetryTest.php
@@ -2,7 +2,22 @@
 
 declare(strict_types=1);
 
+use Cbox\Telemetry\TelemetryServiceProvider;
+
+it('reports the telemetry service provider as not booted when it is not registered', function () {
+    config()->set('queue-autoscale.telemetry.enabled', true);
+    config()->set('telemetry.enabled', true);
+
+    // The shared test harness does not register TelemetryServiceProvider by
+    // default (see TestCase::getPackageProviders), so TelemetryManager is
+    // never bound here even though the package is installed.
+    $this->artisan('queue:autoscale:debug', ['--queue' => 'default'])
+        ->expectsOutputToContain('Telemetry: installed but not booted (telemetry service provider not registered)');
+});
+
 it('reports active telemetry integration in debug output', function () {
+    $this->app->register(TelemetryServiceProvider::class);
+
     config()->set('queue-autoscale.telemetry.enabled', true);
     config()->set('telemetry.enabled', true);
 
@@ -11,6 +26,8 @@ it('reports active telemetry integration in debug output', function () {
 });
 
 it('reports disabled telemetry integration in debug output', function () {
+    $this->app->register(TelemetryServiceProvider::class);
+
     config()->set('queue-autoscale.telemetry.enabled', false);
 
     $this->artisan('queue:autoscale:debug', ['--queue' => 'default'])
@@ -18,6 +35,8 @@ it('reports disabled telemetry integration in debug output', function () {
 });
 
 it('reports inactive telemetry when the host package is off', function () {
+    $this->app->register(TelemetryServiceProvider::class);
+
     config()->set('queue-autoscale.telemetry.enabled', true);
     config()->set('telemetry.enabled', false);
 

--- a/tests/Feature/Telemetry/DebugCommandTelemetryTest.php
+++ b/tests/Feature/Telemetry/DebugCommandTelemetryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+it('reports active telemetry integration in debug output', function () {
+    config()->set('queue-autoscale.telemetry.enabled', true);
+    config()->set('telemetry.enabled', true);
+
+    $this->artisan('queue:autoscale:debug', ['--queue' => 'default'])
+        ->expectsOutputToContain('Telemetry: active');
+});
+
+it('reports disabled telemetry integration in debug output', function () {
+    config()->set('queue-autoscale.telemetry.enabled', false);
+
+    $this->artisan('queue:autoscale:debug', ['--queue' => 'default'])
+        ->expectsOutputToContain('Telemetry: disabled (queue-autoscale.telemetry.enabled)');
+});
+
+it('reports inactive telemetry when the host package is off', function () {
+    config()->set('queue-autoscale.telemetry.enabled', true);
+    config()->set('telemetry.enabled', false);
+
+    $this->artisan('queue:autoscale:debug', ['--queue' => 'default'])
+        ->expectsOutputToContain('Telemetry: inactive (telemetry.enabled is false)');
+});

--- a/tests/Feature/Telemetry/TelemetryBootWiringTest.php
+++ b/tests/Feature/Telemetry/TelemetryBootWiringTest.php
@@ -17,6 +17,15 @@ use Mockery;
 
 final class TelemetryBootWiringTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('requires cboxdk/laravel-telemetry');
+        }
+
+        parent::setUp();
+    }
+
     protected function getPackageProviders($app)
     {
         return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];

--- a/tests/Feature/Telemetry/TelemetryBootWiringTest.php
+++ b/tests/Feature/Telemetry/TelemetryBootWiringTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Events\SlaBreached;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
+use Cbox\LaravelQueueAutoscale\Tests\TestCase;
+use Cbox\Telemetry\TelemetryManager;
+use Cbox\Telemetry\TelemetryServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+
+final class TelemetryBootWiringTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];
+    }
+
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('telemetry.enabled', true);
+        $app['config']->set('telemetry.store', 'array');
+        $app['config']->set('queue-autoscale.telemetry.enabled', true);
+    }
+
+    public function test_it_subscribes_to_package_events_at_boot(): void
+    {
+        foreach ([ScalingDecisionMade::class, WorkersScaled::class, SlaBreached::class] as $event) {
+            $this->assertTrue(Event::hasListeners($event), "No listener registered for {$event}");
+        }
+    }
+
+    public function test_it_registers_the_telemetry_provider_with_the_manager(): void
+    {
+        $snapshot = Mockery::mock(ProvidesTelemetrySnapshot::class);
+        $snapshot->shouldReceive('snapshot')->andReturn(['cluster' => ['manager_count' => 1]]);
+        $this->app->instance(ProvidesTelemetrySnapshot::class, $snapshot);
+
+        $families = $this->app->make(TelemetryManager::class)->collect();
+        $names = array_map(fn ($family) => $family->name(), $families);
+
+        $this->assertContains('queue_autoscale.cluster.managers', $names);
+    }
+
+    public function test_the_event_subscriber_is_a_singleton(): void
+    {
+        $this->assertSame(
+            $this->app->make(TelemetryEventSubscriber::class),
+            $this->app->make(TelemetryEventSubscriber::class),
+        );
+    }
+}

--- a/tests/Feature/Telemetry/TelemetryDisabledTest.php
+++ b/tests/Feature/Telemetry/TelemetryDisabledTest.php
@@ -7,11 +7,21 @@ namespace Cbox\LaravelQueueAutoscale\Tests\Feature\Telemetry;
 use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
 use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
 use Cbox\LaravelQueueAutoscale\Tests\TestCase;
+use Cbox\Telemetry\TelemetryManager;
 use Cbox\Telemetry\TelemetryServiceProvider;
 use Illuminate\Support\Facades\Event;
 
 final class TelemetryDisabledTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('requires cboxdk/laravel-telemetry');
+        }
+
+        parent::setUp();
+    }
+
     protected function getPackageProviders($app)
     {
         return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];

--- a/tests/Feature/Telemetry/TelemetryDisabledTest.php
+++ b/tests/Feature/Telemetry/TelemetryDisabledTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
+use Cbox\LaravelQueueAutoscale\Tests\TestCase;
+use Cbox\Telemetry\TelemetryServiceProvider;
+use Illuminate\Support\Facades\Event;
+
+final class TelemetryDisabledTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [TelemetryServiceProvider::class, ...parent::getPackageProviders($app)];
+    }
+
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('queue-autoscale.telemetry.enabled', false);
+    }
+
+    public function test_it_does_not_subscribe_when_disabled(): void
+    {
+        $this->assertFalse(Event::hasListeners(ScalingDecisionMade::class));
+    }
+
+    public function test_it_does_not_bind_the_event_subscriber_when_disabled(): void
+    {
+        $this->assertFalse($this->app->bound(TelemetryEventSubscriber::class));
+    }
+}

--- a/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
+++ b/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
@@ -2,15 +2,21 @@
 
 declare(strict_types=1);
 
+use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStarted;
 use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStopped;
 use Cbox\LaravelQueueAutoscale\Events\ClusterLeaderChanged;
 use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
 use Cbox\LaravelQueueAutoscale\Events\SlaBreached;
 use Cbox\LaravelQueueAutoscale\Events\SlaRecovered;
 use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Scaling\DTOs\CapacityCalculationResult;
 use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
 use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
 use Cbox\Telemetry\Facades\Telemetry;
+use Cbox\Telemetry\Metrics\Registry;
+use Cbox\Telemetry\Metrics\Stores\ArrayMetricStore;
+use Cbox\Telemetry\TelemetryManager;
+use Cbox\Telemetry\Tracing\Tracer;
 
 function makeScalingDecision(array $overrides = []): ScalingDecision
 {
@@ -39,6 +45,20 @@ it('records scaling decision gauges', function () {
     expect($this->fake->gaugeValue('queue_autoscale.workers.target', $labels))->toBe(5.0)
         ->and($this->fake->gaugeValue('queue_autoscale.sla.predicted_pickup', $labels))->toBe(12.5)
         ->and($this->fake->gaugeValue('queue_autoscale.sla.target', $labels))->toBe(30.0);
+});
+
+it('records the capacity ceiling gauge with its limiting factor label', function () {
+    $capacity = new CapacityCalculationResult(
+        maxWorkersByCpu: 8,
+        maxWorkersByMemory: 12,
+        maxWorkersByConfig: 20,
+        finalMaxWorkers: 8,
+        limitingFactor: 'cpu',
+    );
+
+    $this->subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision(['capacity' => $capacity])));
+
+    expect($this->fake->gaugeValue('queue_autoscale.capacity.max_workers', ['limiter' => 'cpu']))->toBe(8.0);
 });
 
 it('skips the predicted pickup gauge when prediction is null', function () {
@@ -111,4 +131,48 @@ it('records nothing when the events toggle is disabled', function () {
 
     $this->fake->assertCounterNotIncremented('queue_autoscale.scaling.actions');
     $this->fake->assertEventNotEmitted('queue_autoscale.scaling.action');
+});
+
+it('emits a manager started event with the manager and cluster identifiers', function () {
+    $this->subscriber->handleAutoscaleManagerStarted(new AutoscaleManagerStarted(
+        managerId: 'm1', host: 'web-01', clusterEnabled: true, clusterId: 'app-prod',
+        intervalSeconds: 5, startedAt: 1_000, packageVersion: 'dev',
+    ));
+
+    $this->fake->assertEventEmitted('queue_autoscale.manager.started', function ($event): bool {
+        return $event->attributes['manager_id'] === 'm1'
+            && $event->attributes['cluster_id'] === 'app-prod';
+    });
+});
+
+it('debounces flushes for rapid decisions, then flushes again once the window passes', function () {
+    $telemetry = new class(enabled: true, registry: new Registry(new ArrayMetricStore, [1, 5, 10]), tracer: new Tracer(sampleRate: 1.0)) extends TelemetryManager
+    {
+        public int $flushCount = 0;
+
+        public function flush(bool $forceDetails = false): void
+        {
+            $this->flushCount++;
+
+            parent::flush($forceDetails);
+        }
+    };
+
+    app()->instance(TelemetryManager::class, $telemetry);
+
+    // A small, deterministic window instead of the 1-second production
+    // default — keeps the test fast without relying on real-time sleeps
+    // longer than necessary.
+    $subscriber = new TelemetryEventSubscriber(app(), flushIntervalSeconds: 0.05);
+
+    $subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision()));
+    $subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision()));
+
+    expect($telemetry->flushCount)->toBe(1);
+
+    usleep(60_000);
+
+    $subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision()));
+
+    expect($telemetry->flushCount)->toBe(2);
 });

--- a/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
+++ b/tests/Feature/Telemetry/TelemetryEventSubscriberTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Events\AutoscaleManagerStopped;
+use Cbox\LaravelQueueAutoscale\Events\ClusterLeaderChanged;
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Events\SlaBreached;
+use Cbox\LaravelQueueAutoscale\Events\SlaRecovered;
+use Cbox\LaravelQueueAutoscale\Events\WorkersScaled;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
+use Cbox\LaravelQueueAutoscale\Telemetry\TelemetryEventSubscriber;
+use Cbox\Telemetry\Facades\Telemetry;
+
+function makeScalingDecision(array $overrides = []): ScalingDecision
+{
+    return new ScalingDecision(...array_merge([
+        'connection' => 'redis',
+        'queue' => 'default',
+        'currentWorkers' => 2,
+        'targetWorkers' => 5,
+        'reason' => 'backlog growing',
+        'predictedPickupTime' => 12.5,
+        'slaTarget' => 30,
+    ], $overrides));
+}
+
+beforeEach(function () {
+    config()->set('queue-autoscale.telemetry.events', true);
+    $this->fake = Telemetry::fake();
+    $this->subscriber = new TelemetryEventSubscriber(app());
+});
+
+it('records scaling decision gauges', function () {
+    $this->subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision()));
+
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    expect($this->fake->gaugeValue('queue_autoscale.workers.target', $labels))->toBe(5.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.sla.predicted_pickup', $labels))->toBe(12.5)
+        ->and($this->fake->gaugeValue('queue_autoscale.sla.target', $labels))->toBe(30.0);
+});
+
+it('skips the predicted pickup gauge when prediction is null', function () {
+    $this->subscriber->handleScalingDecisionMade(new ScalingDecisionMade(makeScalingDecision(['predictedPickupTime' => null])));
+
+    $names = array_map(fn ($family) => $family->name(), $this->fake->collect());
+
+    expect($names)->not->toContain('queue_autoscale.sla.predicted_pickup');
+});
+
+it('counts scaling actions and emits a scaling action event', function () {
+    $this->subscriber->handleWorkersScaled(new WorkersScaled(
+        connection: 'redis', queue: 'default', from: 2, to: 5, action: 'up', reason: 'backlog',
+    ));
+
+    $this->fake->assertCounterIncremented('queue_autoscale.scaling.actions', [
+        'connection' => 'redis', 'queue' => 'default', 'direction' => 'up',
+    ]);
+    $this->fake->assertEventEmitted('queue_autoscale.scaling.action');
+});
+
+it('sets the breach gauge and counts breaches on sla breach, then clears on recovery', function () {
+    $labels = ['connection' => 'redis', 'queue' => 'default'];
+
+    $this->subscriber->handleSlaBreached(new SlaBreached(
+        connection: 'redis', queue: 'default', oldestJobAge: 45, slaTarget: 30, pending: 100, activeWorkers: 2,
+    ));
+
+    expect($this->fake->gaugeValue('queue_autoscale.sla.breach', $labels))->toBe(1.0);
+    $this->fake->assertCounterIncremented('queue_autoscale.sla.breaches', $labels);
+    $this->fake->assertEventEmitted('queue_autoscale.sla.breached');
+
+    $this->subscriber->handleSlaRecovered(new SlaRecovered(
+        connection: 'redis', queue: 'default', currentJobAge: 5, slaTarget: 30, pending: 3, activeWorkers: 4,
+    ));
+
+    expect($this->fake->gaugeValue('queue_autoscale.sla.breach', $labels))->toBe(0.0);
+    $this->fake->assertEventEmitted('queue_autoscale.sla.recovered');
+});
+
+it('counts leader changes', function () {
+    $this->subscriber->handleClusterLeaderChanged(new ClusterLeaderChanged(
+        clusterId: 'app-prod', previousLeaderId: 'a', currentLeaderId: 'b',
+        observedByManagerId: 'b', changedAt: 1_000,
+    ));
+
+    $this->fake->assertCounterIncremented('queue_autoscale.cluster.leader_changes', []);
+    $this->fake->assertEventEmitted('queue_autoscale.cluster.leader_changed');
+});
+
+it('emits a manager stopped event with uptime', function () {
+    $this->subscriber->handleAutoscaleManagerStopped(new AutoscaleManagerStopped(
+        managerId: 'm1', host: 'web-01', clusterEnabled: false, clusterId: '',
+        startedAt: 1_000_000, stoppedAt: 61_000_000, reason: 'restart_signal',
+        workerCount: 3, packageVersion: 'dev',
+    ));
+
+    $this->fake->assertEventEmitted('queue_autoscale.manager.stopped', function ($event): bool {
+        return $event->attributes['uptime_seconds'] === 60_000.0
+            && $event->attributes['reason'] === 'restart_signal';
+    });
+});
+
+it('records nothing when the events toggle is disabled', function () {
+    config()->set('queue-autoscale.telemetry.events', false);
+
+    $this->subscriber->handleWorkersScaled(new WorkersScaled(
+        connection: 'redis', queue: 'default', from: 2, to: 5, action: 'up', reason: 'backlog',
+    ));
+
+    $this->fake->assertCounterNotIncremented('queue_autoscale.scaling.actions');
+    $this->fake->assertEventNotEmitted('queue_autoscale.scaling.action');
+});

--- a/tests/Feature/Telemetry/TelemetryProviderTest.php
+++ b/tests/Feature/Telemetry/TelemetryProviderTest.php
@@ -59,7 +59,10 @@ it('publishes no samples for an empty cluster snapshot', function () {
     bindClusterSnapshot([]);
     $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
 
-    expect($this->fake->gaugeValue('queue_autoscale.cluster.managers', []))->toBe(0.0);
+    $family = collect($this->fake->collect())->first(fn ($f) => $f->name() === 'queue_autoscale.cluster.managers');
+
+    expect($family)->not->toBeNull()
+        ->and($family->samples)->toBeEmpty();
 });
 
 it('registers no cluster gauges when the gauge group is disabled', function () {
@@ -77,4 +80,9 @@ it('coerces non-numeric summary fields to zero instead of throwing', function ()
     $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
 
     expect($this->fake->gaugeValue('queue_autoscale.cluster.managers', []))->toBe(0.0);
+
+    $hostFamily = collect($this->fake->collect())->first(fn ($f) => $f->name() === 'queue_autoscale.cluster.host.workers');
+
+    expect($hostFamily)->not->toBeNull()
+        ->and($hostFamily->samples)->toBeEmpty();
 });

--- a/tests/Feature/Telemetry/TelemetryProviderTest.php
+++ b/tests/Feature/Telemetry/TelemetryProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\QueueAutoscaleTelemetryProvider;
+use Cbox\Telemetry\Facades\Telemetry;
+
+function bindClusterSnapshot(array $cluster): void
+{
+    $snapshot = Mockery::mock(ProvidesTelemetrySnapshot::class);
+    $snapshot->shouldReceive('snapshot')->andReturn(['cluster' => $cluster]);
+    app()->instance(ProvidesTelemetrySnapshot::class, $snapshot);
+}
+
+function exampleClusterSummary(): array
+{
+    return [
+        'manager_count' => 2,
+        'total_workers' => 14,
+        'required_workers' => 18,
+        'total_worker_capacity' => 40,
+        'utilization_percent' => 35.0,
+        'scale_signal' => ['recommended_hosts' => 3],
+        'managers' => [
+            ['host' => 'web-01', 'total_workers' => 8, 'max_workers' => 20],
+            ['host' => 'web-02', 'total_workers' => 6, 'max_workers' => 20],
+        ],
+    ];
+}
+
+beforeEach(function () {
+    config()->set('queue-autoscale.telemetry.gauges.cluster', true);
+    $this->fake = Telemetry::fake();
+});
+
+it('publishes cluster summary gauges', function () {
+    bindClusterSnapshot(exampleClusterSummary());
+    $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
+
+    expect($this->fake->gaugeValue('queue_autoscale.cluster.managers', []))->toBe(2.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.workers', []))->toBe(14.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.required_workers', []))->toBe(18.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.capacity', []))->toBe(40.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.utilization', []))->toBe(35.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.recommended_hosts', []))->toBe(3.0);
+});
+
+it('publishes per-host gauges labeled by host', function () {
+    bindClusterSnapshot(exampleClusterSummary());
+    $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
+
+    expect($this->fake->gaugeValue('queue_autoscale.cluster.host.workers', ['host' => 'web-01']))->toBe(8.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.host.workers', ['host' => 'web-02']))->toBe(6.0)
+        ->and($this->fake->gaugeValue('queue_autoscale.cluster.host.capacity', ['host' => 'web-01']))->toBe(20.0);
+});
+
+it('publishes no samples for an empty cluster snapshot', function () {
+    bindClusterSnapshot([]);
+    $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
+
+    expect($this->fake->gaugeValue('queue_autoscale.cluster.managers', []))->toBe(0.0);
+});
+
+it('registers no cluster gauges when the gauge group is disabled', function () {
+    config()->set('queue-autoscale.telemetry.gauges.cluster', false);
+    bindClusterSnapshot(exampleClusterSummary());
+    $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
+
+    $names = array_map(fn ($family) => $family->name(), $this->fake->collect());
+
+    expect($names)->not->toContain('queue_autoscale.cluster.managers');
+});
+
+it('coerces non-numeric summary fields to zero instead of throwing', function () {
+    bindClusterSnapshot(['manager_count' => 'garbage', 'managers' => 'not-a-list']);
+    $this->fake->provider(new QueueAutoscaleTelemetryProvider(app()));
+
+    expect($this->fake->gaugeValue('queue_autoscale.cluster.managers', []))->toBe(0.0);
+});

--- a/tests/Feature/Telemetry/TelemetrySnapshotTest.php
+++ b/tests/Feature/Telemetry/TelemetrySnapshotTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueAutoscale\Cluster\ClusterStore;
+use Cbox\LaravelQueueAutoscale\Telemetry\Contracts\ProvidesTelemetrySnapshot;
+use Cbox\LaravelQueueAutoscale\Telemetry\QueueAutoscaleTelemetrySnapshot;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('binds a default snapshot implementation', function () {
+    expect(app()->bound(ProvidesTelemetrySnapshot::class))->toBeTrue()
+        ->and(app(ProvidesTelemetrySnapshot::class))->toBeInstanceOf(QueueAutoscaleTelemetrySnapshot::class);
+});
+
+it('returns an empty cluster snapshot when cluster mode is disabled', function () {
+    config()->set('queue-autoscale.cluster.enabled', false);
+
+    expect(app(ProvidesTelemetrySnapshot::class)->snapshot())->toBe(['cluster' => []]);
+});
+
+it('returns the cluster summary when cluster mode is enabled', function () {
+    config()->set('queue-autoscale.cluster.enabled', true);
+    config()->set('queue-autoscale.telemetry.cache_ttl', 0);
+
+    $store = Mockery::mock(ClusterStore::class);
+    $store->shouldReceive('summary')->once()->andReturn(['manager_count' => 2]);
+    app()->instance(ClusterStore::class, $store);
+
+    expect(app(ProvidesTelemetrySnapshot::class)->snapshot())->toBe(['cluster' => ['manager_count' => 2]]);
+});
+
+it('treats an empty summary as an empty cluster snapshot', function () {
+    config()->set('queue-autoscale.cluster.enabled', true);
+    config()->set('queue-autoscale.telemetry.cache_ttl', 0);
+
+    $store = Mockery::mock(ClusterStore::class);
+    $store->shouldReceive('summary')->once()->andReturn([]);
+    app()->instance(ClusterStore::class, $store);
+
+    expect(app(ProvidesTelemetrySnapshot::class)->snapshot())->toBe(['cluster' => []]);
+});
+
+it('caches the snapshot for cache_ttl seconds', function () {
+    config()->set('queue-autoscale.cluster.enabled', true);
+    config()->set('queue-autoscale.telemetry.cache_ttl', 10);
+
+    $store = Mockery::mock(ClusterStore::class);
+    $store->shouldReceive('summary')->once()->andReturn(['manager_count' => 1]);
+    app()->instance(ClusterStore::class, $store);
+
+    $snapshot = app(ProvidesTelemetrySnapshot::class);
+    $snapshot->snapshot();
+    $snapshot->snapshot();
+});

--- a/tests/Feature/Telemetry/TelemetryUnboundTest.php
+++ b/tests/Feature/Telemetry/TelemetryUnboundTest.php
@@ -7,10 +7,20 @@ namespace Cbox\LaravelQueueAutoscale\Tests\Feature\Telemetry;
 use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
 use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
 use Cbox\LaravelQueueAutoscale\Tests\TestCase;
+use Cbox\Telemetry\TelemetryManager;
 use Illuminate\Support\Facades\Event;
 
 final class TelemetryUnboundTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('requires cboxdk/laravel-telemetry');
+        }
+
+        parent::setUp();
+    }
+
     public function getEnvironmentSetUp($app): void
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Feature/Telemetry/TelemetryUnboundTest.php
+++ b/tests/Feature/Telemetry/TelemetryUnboundTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueAutoscale\Tests\Feature\Telemetry;
+
+use Cbox\LaravelQueueAutoscale\Events\ScalingDecisionMade;
+use Cbox\LaravelQueueAutoscale\Scaling\ScalingDecision;
+use Cbox\LaravelQueueAutoscale\Tests\TestCase;
+use Illuminate\Support\Facades\Event;
+
+final class TelemetryUnboundTest extends TestCase
+{
+    public function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Leave telemetry.enabled at its default (true), but do NOT register
+        // TelemetryServiceProvider, so TelemetryManager is not bound in the container.
+        // This tests the regression where the service provider's bound() guard prevents
+        // crashes when handlers try to resolve TelemetryManager.
+    }
+
+    public function test_it_does_not_subscribe_when_unbound(): void
+    {
+        $this->assertFalse(Event::hasListeners(ScalingDecisionMade::class));
+    }
+
+    public function test_it_does_not_crash_when_dispatching_event_with_unbound_manager(): void
+    {
+        $decision = new ScalingDecision(
+            connection: 'redis',
+            queue: 'default',
+            currentWorkers: 2,
+            targetWorkers: 5,
+            reason: 'backlog growing',
+            predictedPickupTime: 12.5,
+            slaTarget: 30,
+        );
+
+        // Dispatch a real ScalingDecisionMade event. If the service provider's
+        // bound() guard is missing, this would throw BindingResolutionException.
+        // With the guard in place, it completes without listeners or exceptions.
+        event(new ScalingDecisionMade($decision));
+
+        // If we get here, no exception was thrown.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,8 +9,23 @@ use Cbox\LaravelQueueAutoscale\Scaling\Calculators\LinearRegressionForecaster;
 use Cbox\LaravelQueueAutoscale\Scaling\Forecasting\Policies\ModerateForecastPolicy;
 use Cbox\LaravelQueueAutoscale\Tests\TestCase;
 use Cbox\LaravelQueueMetrics\DataTransferObjects\QueueMetricsData;
+use Cbox\Telemetry\TelemetryManager;
 
 uses(TestCase::class)->in(__DIR__);
+
+/**
+ * The telemetry integration lives behind an optional dev dependency
+ * (cboxdk/laravel-telemetry, required on Laravel 12+ only). Skip the
+ * Pest-style telemetry specs cleanly when it isn't installed, e.g. on the
+ * Laravel 11 CI leg, instead of fataling on a missing class.
+ */
+uses()
+    ->beforeEach(function () {
+        if (! class_exists(TelemetryManager::class)) {
+            $this->markTestSkipped('requires cboxdk/laravel-telemetry');
+        }
+    })
+    ->in('Feature/Telemetry');
 
 /**
  * Helper function to build a v2 QueueConfiguration for tests.


### PR DESCRIPTION
## Summary

When `cboxdk/laravel-telemetry` (>= v0.2.0) is installed, the autoscaler automatically publishes its scaling signals to OpenTelemetry — scaling decisions, SLA breach state, capacity limits and cluster gauges. Zero config, no-op when the package is absent, and no duplication of metrics owned by `cboxdk/laravel-queue-metrics` or laravel-telemetry's own queue instrumentation.

Mirrors the integration pattern from queue-metrics: `class_exists` + config + `bound()` guards in the service provider, telemetry-typed classes isolated in `src/Telemetry/`, `TelemetryManager` resolved per call so `Telemetry::fake()` works.

## What's included

- [x] composer require-dev/suggest `^0.2.0`, `telemetry` config block
- [x] Snapshot seam (`ProvidesTelemetrySnapshot`) over the Redis cluster store, cached (`cache_ttl`, default 10s)
- [x] PULL: 8 observable cluster gauges (`queue_autoscale.cluster.*`), only sampled in cluster mode
- [x] PUSH: `TelemetryEventSubscriber` (container **singleton** — required for debounce state; Laravel resolves subscribers per dispatch) — decision/SLA gauges, scaling counters, OTLP events; per-tick handler flushes debounced (1s), rare events flush immediately
- [x] Service provider wiring behind `class_exists` → config → `bound()` guards; unbound-manager crash path pinned by `TelemetryUnboundTest`
- [x] Telemetry status row in `queue:autoscale:debug` (5 states incl. "installed but not booted")
- [x] README metric catalog (16 metrics, verified against code)

## CI changes

- Laravel 11 leg reworked: telemetry requires illuminate 12+, so the L11 job removes the dev dependency first and exercises the "telemetry not installed" path (all telemetry specs skip cleanly — verified both ways locally)
- Revived the `prefer-lowest` axis with one leg (PHP 8.3 / L12) — it had gone entirely dead; resolution verified via dry-run (framework v12.61.1 + testbench v10.2.0)

## Deliberately NOT exported

Queue depth, oldest-job age, health scores, worker busy/idle state, baselines (owned by queue-metrics); per-job durations/outcomes (telemetry's own `QueueInstrumentation`); no active-workers gauge — dashboards join queue-metrics' upcoming `queue_metrics.queue.active_workers` against `queue_autoscale.workers.target`. Spawn-latency gauges deferred.

## Verification

620 tests (1930+ assertions) green, PHPStan clean, Pint clean. Every task went through independent review; final whole-branch review verdict addressed in the last two commits. Note: telemetry requires Laravel 12+ — on L11 the integration is simply unavailable (documented in README + composer suggest).